### PR TITLE
Quick fix for constraints

### DIFF
--- a/easyCore/Fitting/Constraints.py
+++ b/easyCore/Fitting/Constraints.py
@@ -103,10 +103,10 @@ class ConstraintBase(MSONable, metaclass=ABCMeta):
         if self._enabled == enabled_value:
             return
         elif enabled_value:
-            self.get_obj(self.dependent_obj_ids).enabled = True
+            self.get_obj(self.dependent_obj_ids).enabled = False
             self()
         else:
-            self.get_obj(self.dependent_obj_ids).enabled = False
+            self.get_obj(self.dependent_obj_ids).enabled = True
         self._enabled = enabled_value
 
     def __call__(self, *args, no_set: bool = False, **kwargs):

--- a/easyCore/Objects/Groups.py
+++ b/easyCore/Objects/Groups.py
@@ -8,7 +8,7 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 from numbers import Number
-from typing import Union, Type, Optional, TYPE_CHECKING
+from typing import Union, Type, Optional, TYPE_CHECKING, Callable
 
 from easyCore import borg
 from easyCore.Objects.Base import BasedBase, Descriptor
@@ -242,3 +242,16 @@ class BaseCollection(BasedBase, MutableSequence):
         return (
             f"{self.__class__.__name__} `{getattr(self, 'name')}` of length {len(self)}"
         )
+
+    def sort(self, mapping: Callable, reverse: bool = False):
+        """
+        Sort the collection according to the given mapping.
+
+        :param mapping: mapping function to sort the collection. i.e. lambda parameter: parameter.raw_value
+        :type mapping: Callable
+        :param reverse: Reverse the sorting.
+        :type reverse: bool
+        """
+        i = list(self._kwargs.items())
+        i.sort(key=lambda x: mapping(x[1]), reverse=reverse)
+        self._kwargs.reorder(**{k[0]: k[1] for k in i})

--- a/tests/unit_tests/Fitting/test_constraints.py
+++ b/tests/unit_tests/Fitting/test_constraints.py
@@ -91,3 +91,25 @@ def test_ObjConstraint_Multiple(threePars):
     assert p0.raw_value == value
     assert p1.raw_value == value
     assert p2.raw_value == value
+
+def test_ConstraintEnable_Disable(twoPars):
+
+    assert twoPars[0][0].enabled
+    assert twoPars[0][1].enabled
+
+    c = ObjConstraint(twoPars[0][0], '', twoPars[0][1])
+    twoPars[0][0].user_constraints['num_1'] = c
+
+    assert c.enabled
+    assert twoPars[0][1].enabled
+    assert not twoPars[0][0].enabled
+
+    c.enabled = False
+    assert not c.enabled
+    assert twoPars[0][1].enabled
+    assert twoPars[0][0].enabled
+
+    c.enabled = True
+    assert c.enabled
+    assert twoPars[0][1].enabled
+    assert not twoPars[0][0].enabled

--- a/tests/unit_tests/Objects/test_Groups.py
+++ b/tests/unit_tests/Objects/test_Groups.py
@@ -301,7 +301,7 @@ def test_baseCollection_dir(cls):
     expected = {'generate_bindings', 'insert', 'name', 'reverse', 'append', 'to_data_dict', 'as_dict',
                 'REDIRECT', 'interface', 'clear', 'extend', 'pop', 'count', 'remove', 'user_data', 'index',
                 'constraints', 'to_json', 'from_dict', 'get_parameters', 'unsafe_hash', 'get_fit_parameters',
-                'switch_interface', 'data'}
+                'switch_interface', 'data', 'sort'}
     assert not d.difference(expected)
 
 

--- a/tests/unit_tests/Objects/test_Groups.py
+++ b/tests/unit_tests/Objects/test_Groups.py
@@ -477,3 +477,26 @@ def test_baseCollection_set_index_based(cls):
     for item in obj:
         assert obj._borg.map.convert_id_to_key(item) in edges
     assert obj._borg.map.convert_id_to_key(p4) not in edges
+
+
+@pytest.mark.parametrize('cls', class_constructors)
+def test_baseCollection_sort(cls):
+    name = 'test'
+    v = [1, 4, 3, 2, 5]
+    expected = [1, 2, 3, 4, 5]
+    d = cls(name, *[Parameter(f'p{i}', v[i]) for i in range(len(v))])
+    d.sort(lambda x: x.raw_value)
+    for i, item in enumerate(d):
+        assert item.value == expected[i]
+
+
+@pytest.mark.parametrize('cls', class_constructors)
+def test_baseCollection_sort_reverse(cls):
+    name = 'test'
+    v = [1, 4, 3, 2, 5]
+    expected = [1, 2, 3, 4, 5]
+    expected.reverse()
+    d = cls(name, *[Parameter(f'p{i}', v[i]) for i in range(len(v))])
+    d.sort(lambda x: x.raw_value, reverse=True)
+    for i, item in enumerate(d):
+        assert item.raw_value == expected[i]


### PR DESCRIPTION
Dependent objects were not enabled/disabled when a corresponding constraint was enabled/disabled. 
