### PR TITLE
Fix for pint object comparison

### DIFF
--- a/.github/workflows/ci_pip.yaml
+++ b/.github/workflows/ci_pip.yaml
@@ -54,7 +54,7 @@ jobs:
       with:
         python-version: 3.9
 
-    - uses: Gr1N/setup-poetry@v7
+    - uses: Gr1N/setup-poetry@v8
 
     - name: Check Build
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: Gr1N/setup-poetry@v7
+    - uses: Gr1N/setup-poetry@v8
       with:
         poetry-version: 1.1.13
     - name: Install dependencies

--- a/.github/workflows/self_publish_alpha.yml
+++ b/.github/workflows/self_publish_alpha.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         python-version: 3.9
 
-    - uses: Gr1N/setup-poetry@v7
+    - uses: Gr1N/setup-poetry@v8
       with:
         poetry-version: 1.1.13
     - name: Install and build

--- a/easyCore/Objects/Variable.py
+++ b/easyCore/Objects/Variable.py
@@ -240,8 +240,12 @@ class Descriptor(ComponentSerializer):
         if self._callback.fget is not None:
             try:
                 value = self._callback.fget()
-                if value != self._value.magnitude:
+                if hasattr(self._value, "magnitude"):
+                    if value != self._value.magnitude:
+                        self.__deepValueSetter(value)
+                elif value != self._value:
                     self.__deepValueSetter(value)
+
             except Exception as e:
                 raise ValueError(f"Unable to return value:\n{e}")
         r_value = self._value

--- a/easyCore/Objects/Variable.py
+++ b/easyCore/Objects/Variable.py
@@ -240,7 +240,7 @@ class Descriptor(ComponentSerializer):
         if self._callback.fget is not None:
             try:
                 value = self._callback.fget()
-                if value != self._value:
+                if value != self._value.magnitude:
                     self.__deepValueSetter(value)
             except Exception as e:
                 raise ValueError(f"Unable to return value:\n{e}")


### PR DESCRIPTION
Trying to use parameters with units (pint object) causes a check to fail. This might be an issue with `pint` but reverting to previous versions didn't help, so prefer to do a modification here