### PR TITLE
197 move from poetry to hatchling python packaging tools

### DIFF
--- a/.github/workflows/ci_pip.yaml
+++ b/.github/workflows/ci_pip.yaml
@@ -1,38 +1,57 @@
+# SHOULD BE RENAMED TO python-ci.yml TO BE CONSISTENT WITH THE REFLECTOMETRY
+# This workflow will for a variety of Python versions 
+# - install the code base
+# - lint the code base
+# - test the code base
+# - upload the test coverage to codecov
+#
+# It will also
+# - build the package
+# - check the package
+#
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
 name: CI using pip
 
 on: [push, pull_request]
 
 jobs:
-  CI_Testing:
+  Code_Consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1
+      - name: Suggestion to fix issues
+        if: ${{ failure() }}
+        run: |
+            echo "::notice::In project root run 'python.exe -m ruff . --fix' and commit changes to fix issues."
+            exit 1
 
+  Code_Testing:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: |
-        pip install '.[ci]' && pip uninstall -y easysciencecore
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 ./easyCore --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 ./easyCore --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      run: pip install -e '.[dev]'
+
     - name: Test with tox
       run: |
+        pip install tox tox-gh-actions coverage
         tox
+
     - name: Upload coverage
       uses: codecov/codecov-action@v3
       with:
@@ -42,99 +61,24 @@ jobs:
         OS: ${{ matrix.os }}
         PYTHON: ${{ matrix.python-version }}
 
-  test_Packaging:
+  Package_Testing:
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.9
 
-    - uses: Gr1N/setup-poetry@v8
+    - name: Install dependencies and build
+      run: |
+        pip install -e '.[dev]'
+        python -m build
 
     - name: Check Build
       run: |
-        pip install twine
-        poetry build
-        python -m twine check dist/*
-# name: CI using pip
-
-# on: [push, pull_request]
-
-# jobs:
-#   CI_Testing:
-
-#     strategy:
-#       max-parallel: 4
-#       fail-fast: false
-#       matrix:
-#         python-version: ["3.7", "3.8", "3.9", "3.10"]
-#         os: [ubuntu-latest, macos-latest, windows-latest]
-#         experimental: [false]
-#         include:
-#           - python-version: "3.11.0-alpha.1"
-#             os: ubuntu-latest
-#             experimental: true
-
-#     runs-on: ${{ matrix.os }}
-#     continue-on-error: ${{ matrix.experimental }}
-#     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
-#     steps:
-#     - uses: actions/checkout@v3
-
-#     - uses: actions/setup-python@v4
-#       with:
-#         python-version: ${{ matrix.python-version }}
-
-#     - uses: Gr1N/setup-poetry@v7
-
-#     - name: Install dependencies
-#       run: |
-#         poetry update
-
-#     - name: Lint with flake8
-#       run: |
-#         poetry add flake8
-#         # stop the build if there are Python syntax errors or undefined names
-#         poetry run flake8 ./easyCore --count --select=E9,F63,F7,F82 --show-source --statistics
-#         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-#         poetry run flake8 ./easyCore --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
-#     - name: Test with tox
-#       run: |
-#         poetry add -D pytest coverage
-#         poetry run pytest --cov --cov-report=xml
-
-#     - name: Upload coverage
-#       uses: codecov/codecov-action@v1.0.7
-#       with:
-#         name: Pytest coverage
-#         env_vars: OS,PYTHON,GITHUB_ACTIONS,GITHUB_ACTION,GITHUB_REF,GITHUB_REPOSITORY,GITHUB_HEAD_REF,GITHUB_RUN_ID,GITHUB_SHA,COVERAGE_FILE
-#       env:
-#         OS: ${{ matrix.os }}
-#         PYTHON: ${{ matrix.python-version }}
-
-#   test_Packaging:
-
-#     runs-on: ubuntu-latest
-#     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
-#     steps:
-#     - uses: actions/checkout@v3
-
-#     - uses: actions/setup-python@v4
-#       with:
-#         python-version: 3.9
-
-#     - uses: Gr1N/setup-poetry@v7
-
-#     - name: Check Build
-#       run: |
-#         pip install twine
-#         poetry build
-#         python -m twine check dist/*
+        cd ./dist
+        pytest ../

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,4 +1,3 @@
-# SHOULD BE RENAMED TO python-ci.yml TO BE CONSISTENT WITH THE REFLECTOMETRY
 # This workflow will for a variety of Python versions 
 # - install the code base
 # - lint the code base

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ build
 *.app
 *.dmg
 
+# VScode
+.vscode
+
 # Misc
 ..*
 *.log

--- a/Examples/base/plot_baseclass1.py
+++ b/Examples/base/plot_baseclass1.py
@@ -13,13 +13,14 @@ Imports
 Firstly the necessary imports. Notice that we import numpy from easyCore. This is not done for any reason other than
 saving time from multiple imports.
 """
-import matplotlib.pyplot as plt
 
-from easyCore import np
+import matplotlib.pyplot as plt
+import numpy as np
+
 from easyCore.Objects.ObjectClasses import BaseObj
 from easyCore.Objects.ObjectClasses import Parameter
 
-#%%
+# %%
 # Subclassing
 # ***********
 # To include embedded rST, use a line of >= 20 ``#``'s or ``#%%`` between your
@@ -40,7 +41,7 @@ class Pendulum(BaseObj):
         return cls(A, f, p)
 
     def __call__(self, t):
-        return self.A.raw_value * np.sin(2*np.pi*self.f.raw_value*t + self.p.raw_value)
+        return self.A.raw_value * np.sin(2 * np.pi * self.f.raw_value * t + self.p.raw_value)
 
     def plot(self, time, axis=None, **kwargs):
         if axis is None:
@@ -50,7 +51,8 @@ class Pendulum(BaseObj):
         p = axis.plot(time, self(time), **kwargs)
         return p
 
-#%%
+
+# %%
 # Single Example
 # **************
 # To include embedded rST, use a line of >= 20 ``#``'s or ``#%%`` between your
@@ -64,9 +66,9 @@ p2 = Pendulum.from_pars(A=5)
 # Another pendulum with Frequency = 4
 p3 = Pendulum.from_pars(A=5, f=4)
 # Another pendulum with Phase = pi/2
-p4 = Pendulum.from_pars(A=5, f=4, p=np.pi/2)
+p4 = Pendulum.from_pars(A=5, f=4, p=np.pi / 2)
 
-#%%
+# %%
 # Plotting
 
 t = np.linspace(0, 3, 601)
@@ -79,7 +81,7 @@ p3.plot(t, axis=ax3)
 p4.plot(t, axis=ax4)
 fig.show()
 
-#%%
+# %%
 # Multiple Examples
 # *****************
 # To include embedded rST, use a line of >= 20 ``#``'s or ``#%%`` between your
@@ -93,4 +95,3 @@ for pendulum in pendulum_array:
     pendulum.plot(t, label=f'Phase = {pendulum.p}')
 plt.legend(loc='lower right')
 fig.show()
-

--- a/Examples/base/plot_baseclass1.py
+++ b/Examples/base/plot_baseclass1.py
@@ -13,9 +13,11 @@ Imports
 Firstly the necessary imports. Notice that we import numpy from easyCore. This is not done for any reason other than
 saving time from multiple imports.
 """
-from easyCore import np
-from easyCore.Objects.ObjectClasses import BaseObj, Parameter
 import matplotlib.pyplot as plt
+
+from easyCore import np
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 #%%
 # Subclassing

--- a/easyCore/Datasets/xarray.py
+++ b/easyCore/Datasets/xarray.py
@@ -5,14 +5,20 @@
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
-from typing import Callable, Union, TypeVar, List, Tuple, Any, Iterable
-
 import weakref
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import List
+from typing import Tuple
+from typing import TypeVar
+from typing import Union
 
 # import pint_xarray
 import xarray as xr
 
-from easyCore import np, ureg
+from easyCore import np
+from easyCore import ureg
 from easyCore.Fitting.fitting_template import FitResults
 
 T_ = TypeVar("T_")

--- a/easyCore/Datasets/xarray.py
+++ b/easyCore/Datasets/xarray.py
@@ -2,8 +2,8 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.1.0"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.1.0'
 
 import weakref
 from typing import Any
@@ -14,17 +14,18 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
+import numpy as np
+
 # import pint_xarray
 import xarray as xr
 
-from easyCore import np
 from easyCore import ureg
 from easyCore.Fitting.fitting_template import FitResults
 
-T_ = TypeVar("T_")
+T_ = TypeVar('T_')
 
 
-@xr.register_dataset_accessor("easyCore")
+@xr.register_dataset_accessor('easyCore')
 class easyCoreDatasetAccessor:
     """
         Accessor to extend an xarray DataSet to easyCore. These functions can be accessed by `obj.easyCore.func`.
@@ -48,15 +49,15 @@ class easyCoreDatasetAccessor:
         self._obj = xarray_obj
         self._core_object = None
         self.__error_mapper = {}
-        self.sigma_label_prefix = "s_"
-        if self._obj.attrs.get("name", None) is None:
-            self._obj.attrs["name"] = ""
-        if self._obj.attrs.get("description", None) is None:
-            self._obj.attrs["description"] = ""
-        if self._obj.attrs.get("url", None) is None:
-            self._obj.attrs["url"] = ""
-        if self._obj.attrs.get("units", None) is None:
-            self._obj.attrs["units"] = {}
+        self.sigma_label_prefix = 's_'
+        if self._obj.attrs.get('name', None) is None:
+            self._obj.attrs['name'] = ''
+        if self._obj.attrs.get('description', None) is None:
+            self._obj.attrs['description'] = ''
+        if self._obj.attrs.get('url', None) is None:
+            self._obj.attrs['url'] = ''
+        if self._obj.attrs.get('units', None) is None:
+            self._obj.attrs['units'] = {}
 
     @property
     def name(self) -> str:
@@ -66,7 +67,7 @@ class easyCoreDatasetAccessor:
         :return: Common name of the DataSet
         :rtype: str
         """
-        return self._obj.attrs["name"]
+        return self._obj.attrs['name']
 
     @name.setter
     def name(self, new_name: str):
@@ -78,7 +79,7 @@ class easyCoreDatasetAccessor:
         :return: None
         :rtype: None
         """
-        self._obj.attrs["name"] = new_name
+        self._obj.attrs['name'] = new_name
 
     @property
     def description(self) -> str:
@@ -88,7 +89,7 @@ class easyCoreDatasetAccessor:
         :return: Description of the DataSet
         :rtype: str
         """
-        return self._obj.attrs["description"]
+        return self._obj.attrs['description']
 
     @description.setter
     def description(self, new_description: str):
@@ -100,7 +101,7 @@ class easyCoreDatasetAccessor:
         :return: None
         :rtype: None
         """
-        self._obj.attrs["description"] = new_description
+        self._obj.attrs['description'] = new_description
 
     @property
     def url(self) -> str:
@@ -110,7 +111,7 @@ class easyCoreDatasetAccessor:
         :return: URL of the DataSet (empty if no URL)
         :rtype: str
         """
-        return self._obj.attrs["url"]
+        return self._obj.attrs['url']
 
     @url.setter
     def url(self, new_url: str):
@@ -122,7 +123,7 @@ class easyCoreDatasetAccessor:
         :return:None
         :rtype: None
         """
-        self._obj.attrs["url"] = new_url
+        self._obj.attrs['url'] = new_url
 
     @property
     def core_object(self):
@@ -153,7 +154,7 @@ class easyCoreDatasetAccessor:
         self,
         coordinate_name: str,
         coordinate_values: Union[List[T_], np.ndarray],
-        unit: str = "",
+        unit: str = '',
     ):
         """
         Add a coordinate to the DataSet. This can be then be assigned to one or more DataArrays.
@@ -168,7 +169,7 @@ class easyCoreDatasetAccessor:
         :rtype: None
         """
         self._obj.coords[coordinate_name] = coordinate_values
-        self._obj.attrs["units"][coordinate_name] = ureg.Unit(unit)
+        self._obj.attrs['units'][coordinate_name] = ureg.Unit(unit)
 
     def remove_coordinate(self, coordinate_name: str):
         """
@@ -181,7 +182,7 @@ class easyCoreDatasetAccessor:
         :rtype: None
         """
         del self._obj.coords[coordinate_name]
-        del self._obj.attrs["units"][coordinate_name]
+        del self._obj.attrs['units'][coordinate_name]
 
     def add_variable(
         self,
@@ -189,7 +190,7 @@ class easyCoreDatasetAccessor:
         variable_coordinates: Union[str, List[str]],
         variable_values: Union[List[T_], np.ndarray],
         variable_sigma: Union[List[T_], np.ndarray] = None,
-        unit: str = "",
+        unit: str = '',
         auto_sigma: bool = False,
     ):
         """
@@ -218,15 +219,13 @@ class easyCoreDatasetAccessor:
 
         # The variable_coordinates can be any iterable object. Though we would assume list/tuple
         if not isinstance(variable_coordinates, Iterable):
-            raise ValueError("The variable coordinates must be a list of strings")
+            raise ValueError('The variable coordinates must be a list of strings')
 
         # Check to see if the user want to assign a coordinate which does not exist yet.
         known_keys = self._obj.coords.keys()
         for dimension in variable_coordinates:
             if dimension not in known_keys:
-                raise ValueError(
-                    f"The supplied coordinate `{dimension}` must first be defined."
-                )
+                raise ValueError(f'The supplied coordinate `{dimension}` must first be defined.')
 
         # Create  the dataset.
         self._obj[variable_name] = (variable_coordinates, variable_values)
@@ -244,9 +243,7 @@ class easyCoreDatasetAccessor:
                 # CASE 1-3, We have been given a list. Make it a numpy array
                 self.sigma_attach(variable_name, np.array(variable_sigma))
             else:
-                raise ValueError(
-                    "User supplied sigmas must be of the form; Callable fn, numpy array, list"
-                )
+                raise ValueError('User supplied sigmas must be of the form; Callable fn, numpy array, list')
         else:
             # CASE 2, No sigmas have been supplied.
             if auto_sigma:
@@ -254,17 +251,13 @@ class easyCoreDatasetAccessor:
                 self.sigma_generator(variable_name)
 
         # Set units for the newly created DataArray
-        self._obj.attrs["units"][variable_name] = ureg.Unit(unit)
+        self._obj.attrs['units'][variable_name] = ureg.Unit(unit)
         # If a sigma has been attached, attempt to work out the units.
         if unit and variable_sigma is None and auto_sigma:
-            self._obj.attrs["units"][
-                self.sigma_label_prefix + variable_name
-            ] = ureg.Unit(unit + " ** 0.5")
+            self._obj.attrs['units'][self.sigma_label_prefix + variable_name] = ureg.Unit(unit + ' ** 0.5')
         else:
             if auto_sigma:
-                self._obj.attrs["units"][
-                    self.sigma_label_prefix + variable_name
-                ] = ureg.Unit("")
+                self._obj.attrs['units'][self.sigma_label_prefix + variable_name] = ureg.Unit('')
 
     def remove_variable(self, variable_name: str):
         """
@@ -362,7 +355,7 @@ class easyCoreDatasetAccessor:
             c_array.append(da)
             n_array.append(da.name)
 
-        f = xr.concat(c_array, dim="fit_dim")
+        f = xr.concat(c_array, dim='fit_dim')
         f = f.stack(all_x=n_array)
         return f
 
@@ -371,7 +364,7 @@ class easyCoreDatasetAccessor:
         fitter,
         data_arrays: list,
         *args,
-        dask: str = "forbidden",
+        dask: str = 'forbidden',
         fit_kwargs: dict = None,
         fn_kwargs: dict = None,
         vectorized: bool = False,
@@ -416,7 +409,7 @@ class easyCoreDatasetAccessor:
                 # Pull out any sigmas and send them to the fitter.
                 temp = self._obj[self.__error_mapper[variable_label]]
                 temp[xr.ufuncs.isnan(temp)] = 1e5
-                fit_kwargs["weights"] = temp
+                fit_kwargs['weights'] = temp
             # Perform a standard DataArray fit.
             return dataset.easyCore.fit(
                 fitter,
@@ -429,13 +422,9 @@ class easyCoreDatasetAccessor:
             )
         else:
             # In this case we are fitting multiple datasets to the same fn!
-            bdim_f = [
-                self._obj[p].easyCore.fit_prep(fitter.fit_function) for p in data_arrays
-            ]
+            bdim_f = [self._obj[p].easyCore.fit_prep(fitter.fit_function) for p in data_arrays]
             dim_names = [
-                list(self._obj[p].dims.keys())
-                if isinstance(self._obj[p].dims, dict)
-                else self._obj[p].dims
+                list(self._obj[p].dims.keys()) if isinstance(self._obj[p].dims, dict) else self._obj[p].dims
                 for p in data_arrays
             ]
             bdims = [bdim[0] for bdim in bdim_f]
@@ -450,7 +439,7 @@ class easyCoreDatasetAccessor:
                     dims = list(dims.keys())
 
                 def local_fit_func(x, *args, idx=None, **kwargs):
-                    kwargs["vectorize"] = vectorized
+                    kwargs['vectorize'] = vectorized
                     res = xr.apply_ufunc(
                         fs[idx],
                         *bdims[idx],
@@ -459,7 +448,7 @@ class easyCoreDatasetAccessor:
                         kwargs=fn_kwargs,
                         **kwargs,
                     )
-                    if dask != "forbidden":
+                    if dask != 'forbidden':
                         res.compute()
                     return res.stack(all_x=dim_names[idx])
 
@@ -470,30 +459,22 @@ class easyCoreDatasetAccessor:
                 res = []
                 for idx in range(len(fn_array)):
                     res.append(fn_array[idx](x, *args, idx=idx, **kwargs))
-                return xr.DataArray(
-                    np.concatenate(res, axis=0), coords={"all_x": x}, dims="all_x"
-                )
+                return xr.DataArray(np.concatenate(res, axis=0), coords={'all_x': x}, dims='all_x')
 
             fitter.initialize(fitter.fit_object, fit_func)
             try:
-                if fit_kwargs.get("weights", None) is not None:
-                    del fit_kwargs["weights"]
-                x = xr.DataArray(
-                    np.arange(np.sum([y.size for y in y_list])), dims="all_x"
-                )
-                y = xr.DataArray(
-                    np.concatenate(y_list, axis=0), coords={"all_x": x}, dims="all_x"
-                )
+                if fit_kwargs.get('weights', None) is not None:
+                    del fit_kwargs['weights']
+                x = xr.DataArray(np.arange(np.sum([y.size for y in y_list])), dims='all_x')
+                y = xr.DataArray(np.concatenate(y_list, axis=0), coords={'all_x': x}, dims='all_x')
                 f_res = fitter.fit(x, y, **fit_kwargs)
-                f_res = check_sanity_multiple(
-                    f_res, [self._obj[p] for p in data_arrays]
-                )
+                f_res = check_sanity_multiple(f_res, [self._obj[p] for p in data_arrays])
             finally:
                 fitter.fit_function = old_fit_func
             return f_res
 
 
-@xr.register_dataarray_accessor("easyCore")
+@xr.register_dataarray_accessor('easyCore')
 class easyCoreDataarrayAccessor:
     """
     Accessor to extend an xarray DataArray to easyCore. These functions can be accessed by `obj.easyCore.func`.
@@ -503,12 +484,12 @@ class easyCoreDataarrayAccessor:
     def __init__(self, xarray_obj: xr.DataArray):
         self._obj = xarray_obj
         self._core_object = None
-        self.sigma_label_prefix = "s_"
-        if self._obj.attrs.get("computation", None) is None:
-            self._obj.attrs["computation"] = {
-                "precompute_func": None,
-                "compute_func": None,
-                "postcompute_func": None,
+        self.sigma_label_prefix = 's_'
+        if self._obj.attrs.get('computation', None) is None:
+            self._obj.attrs['computation'] = {
+                'precompute_func': None,
+                'compute_func': None,
+                'postcompute_func': None,
             }
 
     def __empty_functional(self) -> Callable:
@@ -562,7 +543,7 @@ class easyCoreDataarrayAccessor:
         :return: Computational function applied to the DataArray
         :rtype: Callable
         """
-        result = self._obj.attrs["computation"]["compute_func"]
+        result = self._obj.attrs['computation']['compute_func']
         if result is None:
             result = self.__empty_functional()
         return result
@@ -577,7 +558,7 @@ class easyCoreDataarrayAccessor:
         :return: None
         :rtype: None
         """
-        self._obj.attrs["computation"]["compute_func"] = new_computational_fn
+        self._obj.attrs['computation']['compute_func'] = new_computational_fn
 
     @property
     def precompute_func(self) -> Callable:
@@ -587,7 +568,7 @@ class easyCoreDataarrayAccessor:
         :return: Computational function applied to the DataArray before fitting
         :rtype: Callable
         """
-        result = self._obj.attrs["computation"]["precompute_func"]
+        result = self._obj.attrs['computation']['precompute_func']
         if result is None:
             result = self.__empty_functional()
         return result
@@ -602,7 +583,7 @@ class easyCoreDataarrayAccessor:
         :return: None
         :rtype: None
         """
-        self._obj.attrs["computation"]["precompute_func"] = new_computational_fn
+        self._obj.attrs['computation']['precompute_func'] = new_computational_fn
 
     @property
     def postcompute_func(self) -> Callable:
@@ -612,7 +593,7 @@ class easyCoreDataarrayAccessor:
         :return: Computational function applied to the DataArray after fitting
         :rtype: Callable
         """
-        result = self._obj.attrs["computation"]["postcompute_func"]
+        result = self._obj.attrs['computation']['postcompute_func']
         if result is None:
             result = self.__empty_functional()
         return result
@@ -627,11 +608,9 @@ class easyCoreDataarrayAccessor:
         :return: None
         :rtype: None
         """
-        self._obj.attrs["computation"]["postcompute_func"] = new_computational_fn
+        self._obj.attrs['computation']['postcompute_func'] = new_computational_fn
 
-    def fit_prep(
-        self, func_in: Callable, bdims=None, dask_chunks=None
-    ) -> Tuple[xr.DataArray, Callable]:
+    def fit_prep(self, func_in: Callable, bdims=None, dask_chunks=None) -> Tuple[xr.DataArray, Callable]:
         """
         Generate boradcasted coordinates for fitting and reform the fitting function into one which can handle xarrays
 
@@ -648,16 +627,12 @@ class easyCoreDataarrayAccessor:
         if bdims is None:
             coords = [self._obj.coords[da].transpose() for da in self._obj.dims]
             bdims = xr.broadcast(*coords)
-        self._obj.attrs["computation"]["compute_func"] = func_in
+        self._obj.attrs['computation']['compute_func'] = func_in
 
         def func(x, *args, vectorize: bool = False, **kwargs):
             old_shape = x.shape
             if not vectorize:
-                xs = [
-                    x_new.flatten()
-                    for x_new in [x, *args]
-                    if isinstance(x_new, np.ndarray)
-                ]
+                xs = [x_new.flatten() for x_new in [x, *args] if isinstance(x_new, np.ndarray)]
                 x_new = np.column_stack(xs)
                 if len(x_new.shape) > 1 and x_new.shape[1] == 1:
                     x_new = x_new.reshape((-1))
@@ -691,7 +666,7 @@ class easyCoreDataarrayAccessor:
             c_array.append(da)
             n_array.append(da.name)
 
-        f = xr.concat(c_array, dim="fit_dim")
+        f = xr.concat(c_array, dim='fit_dim')
         f = f.stack(all_x=n_array)
         return f
 
@@ -702,7 +677,7 @@ class easyCoreDataarrayAccessor:
         fit_kwargs: dict = None,
         fn_kwargs: dict = None,
         vectorize: bool = False,
-        dask: str = "forbidden",
+        dask: str = 'forbidden',
         **kwargs,
     ) -> FitResults:
         """
@@ -749,26 +724,24 @@ class easyCoreDataarrayAccessor:
             """
             Function which will be called by the fitter. This will deal with sending the function the correct data.
             """
-            kwargs["vectorize"] = vectorize
-            res = xr.apply_ufunc(
-                f, *bdims, *args, dask=dask, kwargs=fn_kwargs, **kwargs
-            )
-            if dask != "forbidden":
+            kwargs['vectorize'] = vectorize
+            res = xr.apply_ufunc(f, *bdims, *args, dask=dask, kwargs=fn_kwargs, **kwargs)
+            if dask != 'forbidden':
                 res.compute()
             return res.stack(all_x=dims)
 
         # Set the new callable to the fitter and initialize
         fitter.initialize(fitter.fit_object, local_fit_func)
         # Make easyCore.Fitting.Fitter compatible `x`
-        x_for_fit = xr.concat(bdims, dim="fit_dim")
+        x_for_fit = xr.concat(bdims, dim='fit_dim')
         x_for_fit = x_for_fit.stack(all_x=[d.name for d in bdims])
         try:
             # Deal with any sigmas if supplied
-            if fit_kwargs.get("weights", None) is not None:
-                fit_kwargs["weights"] = xr.DataArray(
-                    np.array(fit_kwargs["weights"]),
-                    dims=["all_x"],
-                    coords={"all_x": x_for_fit.all_x},
+            if fit_kwargs.get('weights', None) is not None:
+                fit_kwargs['weights'] = xr.DataArray(
+                    np.array(fit_kwargs['weights']),
+                    dims=['all_x'],
+                    coords={'all_x': x_for_fit.all_x},
                 )
             # Try to perform a fit
             f_res = fitter.fit(x_for_fit, self._obj.stack(all_x=dims), **fit_kwargs)
@@ -788,7 +761,7 @@ def check_sanity_single(fit_results: FitResults) -> FitResults:
     :return: Modified fit results
     :rtype: FitResults
     """
-    items = ["y_obs", "y_calc", "residual"]
+    items = ['y_obs', 'y_calc', 'residual']
 
     for item in items:
         array = getattr(fit_results, item)
@@ -799,22 +772,20 @@ def check_sanity_single(fit_results: FitResults) -> FitResults:
 
     x_array = fit_results.x
     if isinstance(x_array, xr.DataArray):
-        fit_results.x.name = "axes_broadcast"
+        fit_results.x.name = 'axes_broadcast'
         x_array = x_array.unstack()
         x_dataset = xr.Dataset()
-        dims = [dims for dims in x_array.dims if dims != "fit_dim"]
+        dims = [dims for dims in x_array.dims if dims != 'fit_dim']
         for idx, dim in enumerate(dims):
-            x_dataset[dim + "_broadcast"] = x_array[idx]
-            x_dataset[dim + "_broadcast"].name = dim + "_broadcast"
+            x_dataset[dim + '_broadcast'] = x_array[idx]
+            x_dataset[dim + '_broadcast'].name = dim + '_broadcast'
         fit_results.x_matrices = x_dataset
     else:
         fit_results.x_matrices = x_array
     return fit_results
 
 
-def check_sanity_multiple(
-    fit_results: FitResults, originals: List[xr.DataArray]
-) -> List[FitResults]:
+def check_sanity_multiple(fit_results: FitResults, originals: List[xr.DataArray]) -> List[FitResults]:
     """
     Convert the multifit FitResults from a fitter compatible state to a list of recognizable DataArray states.
 
@@ -839,15 +810,15 @@ def check_sanity_multiple(
         # now the tricky stuff
         current_results.x = item.easyCore.generate_points()
         current_results.y_obs = item.copy()
-        current_results.y_obs.name = f"{item.name}_obs"
+        current_results.y_obs.name = f'{item.name}_obs'
         current_results.y_calc = xr.DataArray(
             fit_results.y_calc[offset : offset + item.size].data,
             dims=item.dims,
             coords=item.coords,
-            name=f"{item.name}_calc",
+            name=f'{item.name}_calc',
         )
         offset += item.size
         current_results.residual = current_results.y_calc - current_results.y_obs
-        current_results.residual.name = f"{item.name}_residual"
+        current_results.residual.name = f'{item.name}_residual'
         return_results.append(current_results)
     return return_results

--- a/easyCore/Fitting/Constraints.py
+++ b/easyCore/Fitting/Constraints.py
@@ -7,14 +7,21 @@ from __future__ import annotations
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
-from abc import abstractmethod, ABCMeta
-
 import weakref
-from asteval import Interpreter
+from abc import ABCMeta
+from abc import abstractmethod
 from numbers import Number
-from typing import List, Union, Callable, TYPE_CHECKING, Optional, TypeVar
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import List
+from typing import Optional
+from typing import TypeVar
+from typing import Union
 
-from easyCore import borg, np
+from asteval import Interpreter
+
+from easyCore import borg
+from easyCore import np
 from easyCore.Objects.core import ComponentSerializer
 
 if TYPE_CHECKING:

--- a/easyCore/Fitting/Constraints.py
+++ b/easyCore/Fitting/Constraints.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.1.0"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.1.0'
 
 import weakref
 from abc import ABCMeta
@@ -18,10 +18,10 @@ from typing import Optional
 from typing import TypeVar
 from typing import Union
 
+import numpy as np
 from asteval import Interpreter
 
 from easyCore import borg
-from easyCore import np
 from easyCore.Objects.core import ComponentSerializer
 
 if TYPE_CHECKING:
@@ -50,35 +50,22 @@ class ConstraintBase(ComponentSerializer, metaclass=ABCMeta):
         self._finalizer = None
         if independent_obj is not None:
             if isinstance(independent_obj, list):
-                self.independent_obj_ids = [
-                    self.get_key(obj) for obj in independent_obj
-                ]
+                self.independent_obj_ids = [self.get_key(obj) for obj in independent_obj]
                 if self.dependent_obj_ids in self.independent_obj_ids:
-                    raise AttributeError(
-                        "A dependent object can not be an independent object"
-                    )
+                    raise AttributeError('A dependent object can not be an independent object')
             else:
                 self.independent_obj_ids = self.get_key(independent_obj)
                 if self.dependent_obj_ids == self.independent_obj_ids:
-                    raise AttributeError(
-                        "A dependent object can not be an independent object"
-                    )
+                    raise AttributeError('A dependent object can not be an independent object')
             # Test if dependent is a parameter or a descriptor.
             # We can not import `Parameter`, so......
-            if dependent_obj.__class__.__name__ == "Parameter":
+            if dependent_obj.__class__.__name__ == 'Parameter':
                 if not dependent_obj.enabled:
-                    raise AssertionError(
-                        "A dependent object needs to be initially enabled."
-                    )
+                    raise AssertionError('A dependent object needs to be initially enabled.')
                 if borg.debug:
-                    print(
-                        f"Dependent variable {dependent_obj}. It should be a `Descriptor`."
-                        f"Setting to fixed"
-                    )
+                    print(f'Dependent variable {dependent_obj}. It should be a `Descriptor`.' f'Setting to fixed')
                 dependent_obj.enabled = False
-                self._finalizer = weakref.finalize(
-                    self, cleanup_constraint, self.dependent_obj_ids, True
-                )
+                self._finalizer = weakref.finalize(self, cleanup_constraint, self.dependent_obj_ids, True)
 
         self.operator = operator
         self.value = value
@@ -131,9 +118,7 @@ class ConstraintBase(ComponentSerializer, metaclass=ABCMeta):
         if isinstance(self.independent_obj_ids, int):
             independent_objs = self.get_obj(self.independent_obj_ids)
         elif isinstance(self.independent_obj_ids, list):
-            independent_objs = [
-                self.get_obj(obj_id) for obj_id in self.independent_obj_ids
-            ]
+            independent_objs = [self.get_obj(obj_id) for obj_id in self.independent_obj_ids]
         if independent_objs is not None:
             value = self._parse_operator(independent_objs, *args, **kwargs)
         else:
@@ -181,7 +166,7 @@ class ConstraintBase(ComponentSerializer, metaclass=ABCMeta):
         return self._borg.map.get_item_by_key(key)
 
 
-C = TypeVar("C", bound=ConstraintBase)
+C = TypeVar('C', bound=ConstraintBase)
 
 
 class NumericConstraint(ConstraintBase):
@@ -214,24 +199,22 @@ class NumericConstraint(ConstraintBase):
              a.value = 2.0
              # `a` is set to the maximum of the constraint (`a = 1`)
         """
-        super(NumericConstraint, self).__init__(
-            dependent_obj, operator=operator, value=value
-        )
+        super(NumericConstraint, self).__init__(dependent_obj, operator=operator, value=value)
 
     def _parse_operator(self, obj: V, *args, **kwargs) -> Number:
         value = obj.raw_value
         if isinstance(value, list):
             value = np.array(value)
-        self.aeval.symtable["value1"] = value
-        self.aeval.symtable["value2"] = self.value
+        self.aeval.symtable['value1'] = value
+        self.aeval.symtable['value2'] = self.value
         try:
-            self.aeval.eval(f"value3 = value1 {self.operator} value2")
-            logic = self.aeval.symtable["value3"]
+            self.aeval.eval(f'value3 = value1 {self.operator} value2')
+            logic = self.aeval.symtable['value3']
             if isinstance(logic, np.ndarray):
-                value[not logic] = self.aeval.symtable["value2"]
+                value[not logic] = self.aeval.symtable['value2']
             else:
                 if not logic:
-                    value = self.aeval.symtable["value2"]
+                    value = self.aeval.symtable['value2']
         except Exception as e:
             raise e
         finally:
@@ -239,7 +222,7 @@ class NumericConstraint(ConstraintBase):
         return value
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__} with `value` {self.operator} {self.value}"
+        return f'{self.__class__.__name__} with `value` {self.operator} {self.value}'
 
 
 class SelfConstraint(ConstraintBase):
@@ -272,22 +255,20 @@ class SelfConstraint(ConstraintBase):
              a.value = 2.0
              # `a` is set to the maximum of the constraint (`a = 1`)
         """
-        super(SelfConstraint, self).__init__(
-            dependent_obj, operator=operator, value=value
-        )
+        super(SelfConstraint, self).__init__(dependent_obj, operator=operator, value=value)
 
     def _parse_operator(self, obj: V, *args, **kwargs) -> Number:
         value = obj.raw_value
-        self.aeval.symtable["value1"] = value
-        self.aeval.symtable["value2"] = getattr(obj, self.value)
+        self.aeval.symtable['value1'] = value
+        self.aeval.symtable['value2'] = getattr(obj, self.value)
         try:
-            self.aeval.eval(f"value3 = value1 {self.operator} value2")
-            logic = self.aeval.symtable["value3"]
+            self.aeval.eval(f'value3 = value1 {self.operator} value2')
+            logic = self.aeval.symtable['value3']
             if isinstance(logic, np.ndarray):
-                value[not logic] = self.aeval.symtable["value2"]
+                value[not logic] = self.aeval.symtable['value2']
             else:
                 if not logic:
-                    value = self.aeval.symtable["value2"]
+                    value = self.aeval.symtable['value2']
         except Exception as e:
             raise e
         finally:
@@ -295,9 +276,7 @@ class SelfConstraint(ConstraintBase):
         return value
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__} with `value` {self.operator} obj.{self.value}"
-        )
+        return f'{self.__class__.__name__} with `value` {self.operator} obj.{self.value}'
 
 
 class ObjConstraint(ConstraintBase):
@@ -331,17 +310,15 @@ class ObjConstraint(ConstraintBase):
              a.value # Should equal 2
 
         """
-        super(ObjConstraint, self).__init__(
-            dependent_obj, independent_obj=independent_obj, operator=operator
-        )
+        super(ObjConstraint, self).__init__(dependent_obj, independent_obj=independent_obj, operator=operator)
         self.external = True
 
     def _parse_operator(self, obj: V, *args, **kwargs) -> Number:
         value = obj.raw_value
-        self.aeval.symtable["value1"] = value
+        self.aeval.symtable['value1'] = value
         try:
-            self.aeval.eval(f"value2 = {self.operator} value1")
-            value = self.aeval.symtable["value2"]
+            self.aeval.eval(f'value2 = {self.operator} value1')
+            value = self.aeval.symtable['value2']
         except Exception as e:
             raise e
         finally:
@@ -349,7 +326,7 @@ class ObjConstraint(ConstraintBase):
         return value
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__} with `dependent_obj` = {self.operator} `independent_obj`"
+        return f'{self.__class__.__name__} with `dependent_obj` = {self.operator} `independent_obj`'
 
 
 class MultiObjConstraint(ConstraintBase):
@@ -424,18 +401,16 @@ class MultiObjConstraint(ConstraintBase):
         self.external = True
 
     def _parse_operator(self, independent_objs: List[V], *args, **kwargs) -> Number:
-        in_str = ""
+        in_str = ''
         value = None
         for idx, obj in enumerate(independent_objs):
-            self.aeval.symtable[
-                "p" + str(self.independent_obj_ids[idx])
-            ] = obj.raw_value
-            in_str += " p" + str(self.independent_obj_ids[idx])
+            self.aeval.symtable['p' + str(self.independent_obj_ids[idx])] = obj.raw_value
+            in_str += ' p' + str(self.independent_obj_ids[idx])
             if idx < len(self.operator):
-                in_str += " " + self.operator[idx]
+                in_str += ' ' + self.operator[idx]
         try:
-            self.aeval.eval(f"final_value = {self.value} - ({in_str})")
-            value = self.aeval.symtable["final_value"]
+            self.aeval.eval(f'final_value = {self.value} - ({in_str})')
+            value = self.aeval.symtable['final_value']
         except Exception as e:
             raise e
         finally:
@@ -443,7 +418,7 @@ class MultiObjConstraint(ConstraintBase):
         return value
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}"
+        return f'{self.__class__.__name__}'
 
 
 class FunctionalConstraint(ConstraintBase):
@@ -480,26 +455,24 @@ class FunctionalConstraint(ConstraintBase):
             # This triggers the constraint
             a.value = -0.5 # `a` is set to 0.5
         """
-        super(FunctionalConstraint, self).__init__(
-            dependent_obj, independent_obj=independent_objs
-        )
+        super(FunctionalConstraint, self).__init__(dependent_obj, independent_obj=independent_objs)
         self.function = func
         if independent_objs is not None:
             self.external = True
 
     def _parse_operator(self, obj: V, *args, **kwargs) -> Number:
-        self.aeval.symtable[f"f{id(self.function)}"] = self.function
-        value_str = f"r_value = f{id(self.function)}("
+        self.aeval.symtable[f'f{id(self.function)}'] = self.function
+        value_str = f'r_value = f{id(self.function)}('
         if isinstance(obj, list):
             for o in obj:
-                value_str += f"{o.raw_value},"
+                value_str += f'{o.raw_value},'
             value_str = value_str[:-1]
         else:
-            value_str += f"{obj.raw_value}"
-        value_str += ")"
+            value_str += f'{obj.raw_value}'
+        value_str += ')'
         try:
             self.aeval.eval(value_str)
-            value = self.aeval.symtable["r_value"]
+            value = self.aeval.symtable['r_value']
         except Exception as e:
             raise e
         finally:
@@ -507,7 +480,7 @@ class FunctionalConstraint(ConstraintBase):
         return value
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}"
+        return f'{self.__class__.__name__}'
 
 
 def cleanup_constraint(obj_id: str, enabled: bool):
@@ -516,4 +489,4 @@ def cleanup_constraint(obj_id: str, enabled: bool):
         obj.enabled = enabled
     except ValueError:
         if borg.debug:
-            print(f"Object with ID {obj_id} has already been deleted")
+            print(f'Object with ID {obj_id} has already been deleted')

--- a/easyCore/Fitting/DFO_LS.py
+++ b/easyCore/Fitting/DFO_LS.py
@@ -9,7 +9,6 @@ from typing import List, Optional
 from numbers import Number
 
 from easyCore.Fitting.fitting_template import (
-    Union,
     Callable,
     FittingTemplate,
     np,

--- a/easyCore/Fitting/DFO_LS.py
+++ b/easyCore/Fitting/DFO_LS.py
@@ -5,20 +5,19 @@
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
-from typing import List, Optional
 from numbers import Number
-
-from easyCore.Fitting.fitting_template import (
-    Callable,
-    FittingTemplate,
-    np,
-    FitResults,
-    NameConverter,
-    FitError,
-)
+from typing import List
+from typing import Optional
 
 # Import dfols specific objects
 import dfols
+
+from easyCore.Fitting.fitting_template import Callable
+from easyCore.Fitting.fitting_template import FitError
+from easyCore.Fitting.fitting_template import FitResults
+from easyCore.Fitting.fitting_template import FittingTemplate
+from easyCore.Fitting.fitting_template import NameConverter
+from easyCore.Fitting.fitting_template import np
 
 
 class DFO(FittingTemplate):  # noqa: S101

--- a/easyCore/Fitting/Fitting.py
+++ b/easyCore/Fitting/Fitting.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.0.1"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.0.1'
 
 import functools
 
@@ -16,14 +16,15 @@ from typing import List
 from typing import Optional
 from typing import TypeVar
 
+import numpy as np
+
 import easyCore.Fitting as Fitting
 from easyCore import borg
 from easyCore import default_fitting_engine
-from easyCore import np
 from easyCore.Objects.Groups import BaseCollection
 
-_C = TypeVar("_C", bound=ABCMeta)
-_M = TypeVar("_M", bound=Fitting.FittingTemplate)
+_C = TypeVar('_C', bound=ABCMeta)
+_M = TypeVar('_M', bound=Fitting.FittingTemplate)
 
 if TYPE_CHECKING:
     from easyCore.Fitting.fitting_template import FitResults as FR
@@ -37,10 +38,7 @@ class Fitter:
 
     _borg = borg
 
-    def __init__(
-        self, fit_object: Optional[B] = None, fit_function: Optional[Callable] = None
-    ):
-
+    def __init__(self, fit_object: Optional[B] = None, fit_function: Optional[Callable] = None):
         self._fit_object = fit_object
         self._fit_function = fit_function
         self._dependent_dims = None
@@ -62,7 +60,7 @@ class Fitter:
         fit_methods = [
             x
             for x, y in Fitting.FittingTemplate.__dict__.items()
-            if (isinstance(y, FunctionType) and not x.startswith("_")) and x != "fit"
+            if (isinstance(y, FunctionType) and not x.startswith('_')) and x != 'fit'
         ]
         for method_name in fit_methods:
             setattr(self, method_name, self.__pass_through_generator(method_name))
@@ -122,9 +120,7 @@ class Fitter:
             self._current_engine = self._engines[engines.index(engine_name)]
             self._is_initialized = False
         else:
-            raise AttributeError(
-                f"The supplied optimizer engine '{engine_name}' is unknown."
-            )
+            raise AttributeError(f"The supplied optimizer engine '{engine_name}' is unknown.")
 
     def switch_engine(self, engine_name: str):
         """
@@ -134,9 +130,7 @@ class Fitter:
         """
         # There isn't any state to carry over
         if not self._is_initialized:
-            raise ReferenceError(
-                "The fitting engine must be initialized before switching"
-            )
+            raise ReferenceError('The fitting engine must be initialized before switching')
         # Constrains are not carried over. Do it manually.
         constraints = self.__engine_obj._constraints
         self.create(engine_name)
@@ -152,9 +146,7 @@ class Fitter:
         :rtype: List[str]
         """
         if Fitting.engines is None:
-            raise ImportError(
-                "There are no available fitting engines. Install `lmfit` and/or `bumps`"
-            )
+            raise ImportError('There are no available fitting engines. Install `lmfit` and/or `bumps`')
         return [engine.name for engine in Fitting.engines]
 
     @property
@@ -233,12 +225,10 @@ class Fitter:
 
         def inner(*args, **kwargs):
             if not obj.can_fit:
-                raise ReferenceError("The fitting engine must first be initialized")
+                raise ReferenceError('The fitting engine must first be initialized')
             func = getattr(obj.engine, name, None)
             if func is None:
-                raise ValueError(
-                    'The fitting engine does not have the attribute "{}"'.format(name)
-                )
+                raise ValueError('The fitting engine does not have the attribute "{}"'.format(name))
             return func(*args, **kwargs)
 
         return inner
@@ -268,19 +258,15 @@ class Fitter:
             """
             # Check to see if we can perform a fit
             if not self.can_fit:
-                raise ReferenceError("The fitting engine must first be initialized")
+                raise ReferenceError('The fitting engine must first be initialized')
 
             # Precompute - Reshape all independents into the correct dimensionality
-            x_fit, x_new, y_new, weights, dims, kwargs = self._precompute_reshaping(
-                x, y, weights, vectorized, kwargs
-            )
+            x_fit, x_new, y_new, weights, dims, kwargs = self._precompute_reshaping(x, y, weights, vectorized, kwargs)
             self._dependent_dims = dims
 
             # Fit
             fit_fun = self._fit_function
-            fit_fun_wrap = self._fit_function_wrapper(
-                x_new, flatten=True
-            )  # This should be wrapped.
+            fit_fun_wrap = self._fit_function_wrapper(x_new, flatten=True)  # This should be wrapped.
 
             # We change the  fit function, so have to  reset constraints
             constraints = self.__engine_obj._constraints
@@ -324,21 +310,19 @@ class Fitter:
             if vectorized:
                 # Assert that the shapes are the same
                 if np.all(x_shape[:-1] != y_new.shape):
-                    raise ValueError("The shape of the x and y data must be the same")
+                    raise ValueError('The shape of the x and y data must be the same')
                 # If so do nothing but note that the data is vectorized
                 # x_shape = (-1,) # Should this be done?
             else:
                 # Assert that the shapes are the same
                 if np.prod(x_new.shape[:-1]) != y_new.size:
-                    raise ValueError(
-                        "The number of elements in x and y data must be the same"
-                    )
+                    raise ValueError('The number of elements in x and y data must be the same')
                 # Reshape the data to be [len(NxMx..), Ndims] i.e. flatten to columns
-                x_new = x_new.reshape(-1, x_shape[-1], order="F")
+                x_new = x_new.reshape(-1, x_shape[-1], order='F')
         else:
             # Assert that the shapes are the same
             if np.all(x_shape != y_new.shape):
-                raise ValueError("The shape of the x and y data must be the same")
+                raise ValueError('The shape of the x and y data must be the same')
             # It is 1D data
             x_new = x.flatten()
         # The optimizer needs a 1D array, flatten the y data
@@ -350,9 +334,7 @@ class Fitter:
         return x_for_fit, x_new, y_new, weights, x_shape, kwargs
 
     @staticmethod
-    def _post_compute_reshaping(
-        fit_result: FR, x: np.ndarray, y: np.ndarray, weights: np.ndarray
-    ) -> FR:
+    def _post_compute_reshaping(fit_result: FR, x: np.ndarray, y: np.ndarray, weights: np.ndarray) -> FR:
         """
         Reshape the output of the fitter into the correct dimensions.
         :param fit_result: Output from the fitter
@@ -360,10 +342,10 @@ class Fitter:
         :param y: Input y dependent
         :return: Reshaped Fit Results
         """
-        setattr(fit_result, "x", x)
-        setattr(fit_result, "y_obs", y)
-        setattr(fit_result, "y_calc", np.reshape(fit_result.y_calc, y.shape))
-        setattr(fit_result, "y_err", np.reshape(fit_result.y_err, y.shape))
+        setattr(fit_result, 'x', x)
+        setattr(fit_result, 'y_obs', y)
+        setattr(fit_result, 'y_calc', np.reshape(fit_result.y_calc, y.shape))
+        setattr(fit_result, 'y_err', np.reshape(fit_result.y_err, y.shape))
         return fit_result
 
 
@@ -378,9 +360,8 @@ class MultiFitter(Fitter):
         fit_objects: Optional[List[B]] = None,
         fit_functions: Optional[List[Callable]] = None,
     ):
-
         # Create a dummy core object to hold all the fit objects.
-        self._fit_objects = BaseCollection("multi", *fit_objects)
+        self._fit_objects = BaseCollection('multi', *fit_objects)
         self._fit_functions = fit_functions
         # Initialize with the first of the fit_functions, without this it is
         # not possible to change the fitting engine.
@@ -398,9 +379,7 @@ class MultiFitter(Fitter):
         wrapped_fns = []
         for this_x, this_fun in zip(real_x, self._fit_functions):
             self._fit_function = this_fun
-            wrapped_fns.append(
-                Fitter._fit_function_wrapper(self, this_x, flatten=flatten)
-            )
+            wrapped_fns.append(Fitter._fit_function_wrapper(self, this_x, flatten=flatten))
 
         def wrapped_fun(x, **kwargs):
             # Generate an empty Y based on x
@@ -434,17 +413,13 @@ class MultiFitter(Fitter):
         """
         if weights is None:
             weights = [None] * len(x)
-        _, _x_new, _y_new, _weights, _dims, kwargs = Fitter._precompute_reshaping(
-            x[0], y[0], weights[0], vectorized, kwargs
-        )
+        _, _x_new, _y_new, _weights, _dims, kwargs = Fitter._precompute_reshaping(x[0], y[0], weights[0], vectorized, kwargs)
         x_new = [_x_new]
         y_new = [_y_new]
         w_new = [_weights]
         dims = [_dims]
         for _x, _y, _w in zip(x[1::], y[1::], weights[1::]):
-            _, _x_new, _y_new, _weights, _dims, _ = Fitter._precompute_reshaping(
-                _x, _y, _w, vectorized, kwargs
-            )
+            _, _x_new, _y_new, _weights, _dims, _ = Fitter._precompute_reshaping(_x, _y, _w, vectorized, kwargs)
             x_new.append(_x_new)
             y_new.append(_y_new)
             w_new.append(_weights)
@@ -487,12 +462,8 @@ class MultiFitter(Fitter):
             current_results.p0 = fit_result_obj.p0
             current_results.x = this_x
             current_results.y_obs = y[idx]
-            current_results.y_calc = np.reshape(
-                fit_result_obj.y_calc[sp:ep], current_results.y_obs.shape
-            )
-            current_results.y_err = np.reshape(
-                fit_result_obj.y_err[sp:ep], current_results.y_obs.shape
-            )
+            current_results.y_calc = np.reshape(fit_result_obj.y_calc[sp:ep], current_results.y_obs.shape)
+            current_results.y_err = np.reshape(fit_result_obj.y_err[sp:ep], current_results.y_obs.shape)
             current_results.engine_result = fit_result_obj.engine_result
 
             # Attach an additional field for the un-modified results

--- a/easyCore/Fitting/Fitting.py
+++ b/easyCore/Fitting/Fitting.py
@@ -8,22 +8,26 @@ import functools
 #  SPDX-FileCopyrightText: 2023 easyCore contributors  <core@easyscience.software>
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
-
 from abc import ABCMeta
 from types import FunctionType
-from typing import List, Callable, TypeVar, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import List
+from typing import Optional
+from typing import TypeVar
 
-from easyCore import borg, default_fitting_engine, np
 import easyCore.Fitting as Fitting
+from easyCore import borg
+from easyCore import default_fitting_engine
+from easyCore import np
 from easyCore.Objects.Groups import BaseCollection
-
 
 _C = TypeVar("_C", bound=ABCMeta)
 _M = TypeVar("_M", bound=Fitting.FittingTemplate)
 
 if TYPE_CHECKING:
-    from easyCore.Utils.typing import B
     from easyCore.Fitting.fitting_template import FitResults as FR
+    from easyCore.Utils.typing import B
 
 
 class Fitter:

--- a/easyCore/Fitting/bumps.py
+++ b/easyCore/Fitting/bumps.py
@@ -9,7 +9,6 @@ import inspect
 from typing import List, Optional
 
 from easyCore.Fitting.fitting_template import (
-    Union,
     Callable,
     FittingTemplate,
     np,

--- a/easyCore/Fitting/bumps.py
+++ b/easyCore/Fitting/bumps.py
@@ -6,20 +6,21 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 import inspect
-from typing import List, Optional
+from typing import List
+from typing import Optional
 
-from easyCore.Fitting.fitting_template import (
-    Callable,
-    FittingTemplate,
-    np,
-    FitResults,
-    NameConverter,
-    FitError,
-)
-
-from bumps.names import Curve, FitProblem
+from bumps.fitters import FIT_AVAILABLE_IDS
+from bumps.fitters import fit as bumps_fit
+from bumps.names import Curve
+from bumps.names import FitProblem
 from bumps.parameter import Parameter as bumpsParameter
-from bumps.fitters import fit as bumps_fit, FIT_AVAILABLE_IDS
+
+from easyCore.Fitting.fitting_template import Callable
+from easyCore.Fitting.fitting_template import FitError
+from easyCore.Fitting.fitting_template import FitResults
+from easyCore.Fitting.fitting_template import FittingTemplate
+from easyCore.Fitting.fitting_template import NameConverter
+from easyCore.Fitting.fitting_template import np
 
 
 class bumps(FittingTemplate):  # noqa: S101

--- a/easyCore/Fitting/fitting_template.py
+++ b/easyCore/Fitting/fitting_template.py
@@ -1,5 +1,5 @@
-__author__ = "github.com/wardsimon"
-__version__ = "0.1.0"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.1.0'
 
 
 #  SPDX-FileCopyrightText: 2023 easyCore contributors  <core@easyscience.software>
@@ -13,7 +13,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from easyCore import np
+import numpy as np
 
 
 class FittingTemplate(metaclass=ABCMeta):
@@ -23,14 +23,14 @@ class FittingTemplate(metaclass=ABCMeta):
 
     _engines = []
     property_type = None
-    name: str = ""
+    name: str = ''
 
     def __init_subclass__(cls, is_abstract: bool = False, **kwargs):
         super().__init_subclass__(**kwargs)
         if not is_abstract:
             # Deal with the issue of people not reading the schema.
-            if not hasattr(cls, "name"):
-                setattr(cls, "name", cls.__class__.__name__)
+            if not hasattr(cls, 'name'):
+                setattr(cls, 'name', cls.__class__.__name__)
             cls._engines.append(cls)
 
     def __init__(self, obj, fit_function: Callable):
@@ -125,7 +125,7 @@ class FittingTemplate(metaclass=ABCMeta):
         if new_parameters is None:
             new_parameters = {}
         for name, item in pars.items():
-            fit_name = "p" + str(name)
+            fit_name = 'p' + str(name)
             if fit_name not in new_parameters.keys():
                 new_parameters[fit_name] = item.raw_value
 
@@ -159,7 +159,7 @@ class FittingTemplate(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def _gen_fit_results(self, fit_results, **kwargs) -> "FitResults":
+    def _gen_fit_results(self, fit_results, **kwargs) -> 'FitResults':
         """
         Convert fit results into the unified `FitResults` format.
 
@@ -178,9 +178,7 @@ class FittingTemplate(metaclass=ABCMeta):
         """
 
     @staticmethod
-    def _error_from_jacobian(
-        jacobian: np.ndarray, residuals: np.ndarray, confidence: float = 0.95
-    ) -> np.ndarray:
+    def _error_from_jacobian(jacobian: np.ndarray, residuals: np.ndarray, confidence: float = 0.95) -> np.ndarray:
         from scipy import stats
 
         JtJi = np.linalg.inv(np.dot(jacobian.T, jacobian))
@@ -202,18 +200,18 @@ class FitResults:
     """
 
     __slots__ = [
-        "success",
-        "fitting_engine",
-        "fit_args",
-        "p",
-        "p0",
-        "x",
-        "x_matrices",
-        "y_obs",
-        "y_calc",
-        "y_err",
-        "engine_result",
-        "total_results",
+        'success',
+        'fitting_engine',
+        'fit_args',
+        'p',
+        'p0',
+        'x',
+        'x_matrices',
+        'y_obs',
+        'y_calc',
+        'y_err',
+        'engine_result',
+        'total_results',
     ]
 
     def __init__(self):
@@ -254,7 +252,7 @@ class NameConverter:
         self._borg = borg
 
     def get_name_from_key(self, item_key: int) -> str:
-        return getattr(self._borg.map.get_item_by_key(item_key), "name", "")
+        return getattr(self._borg.map.get_item_by_key(item_key), 'name', '')
 
     def get_item_from_key(self, item_key: int) -> object:
         return self._borg.map.get_item_by_key(item_key)
@@ -268,7 +266,7 @@ class FitError(Exception):
         self.e = e
 
     def __str__(self) -> str:
-        s = ""
+        s = ''
         if self.e is not None:
-            s = f"{self.e}\n"
-        return s + "Something has gone wrong with the fit"
+            s = f'{self.e}\n'
+        return s + 'Something has gone wrong with the fit'

--- a/easyCore/Fitting/fitting_template.py
+++ b/easyCore/Fitting/fitting_template.py
@@ -6,8 +6,12 @@ __version__ = "0.1.0"
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
-from abc import ABCMeta, abstractmethod
-from typing import Union, Callable, List, Optional
+from abc import ABCMeta
+from abc import abstractmethod
+from typing import Callable
+from typing import List
+from typing import Optional
+from typing import Union
 
 from easyCore import np
 

--- a/easyCore/Fitting/lmfit.py
+++ b/easyCore/Fitting/lmfit.py
@@ -6,20 +6,22 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 import inspect
-from typing import List, Optional
+from typing import List
+from typing import Optional
 
-from easyCore.Fitting.fitting_template import (
-    Callable,
-    FittingTemplate,
-    np,
-    FitResults,
-    NameConverter,
-    FitError,
-)
+from lmfit import Model as lmModel
 
 # Import lmfit specific objects
-from lmfit import Parameter as lmParameter, Parameters as lmParameters, Model as lmModel
+from lmfit import Parameter as lmParameter
+from lmfit import Parameters as lmParameters
 from lmfit.model import ModelResult
+
+from easyCore.Fitting.fitting_template import Callable
+from easyCore.Fitting.fitting_template import FitError
+from easyCore.Fitting.fitting_template import FitResults
+from easyCore.Fitting.fitting_template import FittingTemplate
+from easyCore.Fitting.fitting_template import NameConverter
+from easyCore.Fitting.fitting_template import np
 
 
 class lmfit(FittingTemplate):  # noqa: S101

--- a/easyCore/Fitting/lmfit.py
+++ b/easyCore/Fitting/lmfit.py
@@ -9,7 +9,6 @@ import inspect
 from typing import List, Optional
 
 from easyCore.Fitting.fitting_template import (
-    Union,
     Callable,
     FittingTemplate,
     np,

--- a/easyCore/Objects/Borg.py
+++ b/easyCore/Objects/Borg.py
@@ -6,8 +6,8 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 from easyCore.Objects.Graph import Graph
-from easyCore.Utils.Hugger.Hugger import ScriptManager
 from easyCore.Utils.classUtils import singleton
+from easyCore.Utils.Hugger.Hugger import ScriptManager
 from easyCore.Utils.Logging import Logger
 
 

--- a/easyCore/Objects/Graph.py
+++ b/easyCore/Objects/Graph.py
@@ -5,12 +5,14 @@
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
-import weakref
 import sys
-from typing import List, Union
-from weakref import WeakKeyDictionary
+import weakref
 from collections import defaultdict
-from uuid import uuid4, UUID
+from typing import List
+from typing import Union
+from uuid import UUID
+from uuid import uuid4
+from weakref import WeakKeyDictionary
 
 
 class _EntryList(list):

--- a/easyCore/Objects/Groups.py
+++ b/easyCore/Objects/Groups.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.1.0"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.1.0'
 
 from collections.abc import MutableSequence
 from numbers import Number
@@ -69,9 +69,7 @@ class BaseCollection(BasedBase, MutableSequence):
         kwargs = _kwargs
         for item in list(kwargs.values()) + _args:
             if not issubclass(type(item), (Descriptor, BasedBase)):
-                raise AttributeError(
-                    "A collection can only be formed from easyCore objects."
-                )
+                raise AttributeError('A collection can only be formed from easyCore objects.')
         args = _args
         _kwargs = {}
         for key, item in kwargs.items():
@@ -85,11 +83,9 @@ class BaseCollection(BasedBase, MutableSequence):
 
         for key in kwargs.keys():
             if key in self.__dict__.keys() or key in self.__slots__:
-                raise AttributeError(
-                    f"Given kwarg: `{key}`, is an internal attribute. Please rename."
-                )
+                raise AttributeError(f'Given kwarg: `{key}`, is an internal attribute. Please rename.')
             self._borg.map.add_edge(self, kwargs[key])
-            self._borg.map.reset_type(kwargs[key], "created_internal")
+            self._borg.map.reset_type(kwargs[key], 'created_internal')
             if interface is not None:
                 kwargs[key].interface = interface
             # TODO wrap getter and setter in Logger
@@ -119,12 +115,10 @@ class BaseCollection(BasedBase, MutableSequence):
             self._kwargs.reorder(**{k: v for k, v in zip(update_key, values)})
             # ADD EDGE
             self._borg.map.add_edge(self, value)
-            self._borg.map.reset_type(value, "created_internal")
+            self._borg.map.reset_type(value, 'created_internal')
             value.interface = self.interface
         else:
-            raise AttributeError(
-                "Only easyCore objects can be put into an easyCore group"
-            )
+            raise AttributeError('Only easyCore objects can be put into an easyCore group')
 
     def __getitem__(self, idx: Union[int, slice]) -> Union[V, B]:
         """
@@ -137,30 +131,26 @@ class BaseCollection(BasedBase, MutableSequence):
         """
         if isinstance(idx, slice):
             start, stop, step = idx.indices(len(self))
-            return self.__class__(
-                getattr(self, "name"), *[self[i] for i in range(start, stop, step)]
-            )
+            return self.__class__(getattr(self, 'name'), *[self[i] for i in range(start, stop, step)])
         if str(idx) in self._kwargs.keys():
             return self._kwargs[str(idx)]
         if isinstance(idx, str):
             idx = [index for index, item in enumerate(self) if item.name == idx]
-            l = len(idx)
-            if l == 0:
-                raise IndexError("Given index does not exist")
-            elif l == 1:
+            noi = len(idx)
+            if noi == 0:
+                raise IndexError('Given index does not exist')
+            elif noi == 1:
                 idx = idx[0]
             else:
-                return self.__class__(getattr(self, "name"), *[self[i] for i in idx])
+                return self.__class__(getattr(self, 'name'), *[self[i] for i in idx])
         elif not isinstance(idx, int) or isinstance(idx, bool):
             if isinstance(idx, bool):
-                raise TypeError("Boolean indexing is not supported at the moment")
+                raise TypeError('Boolean indexing is not supported at the moment')
             try:
                 if idx > len(self):
-                    raise IndexError(f"Given index {idx} is out of bounds")
+                    raise IndexError(f'Given index {idx} is out of bounds')
             except TypeError:
-                raise IndexError(
-                    "Index must be of type `int`/`slice` or an item name (`str`)"
-                )
+                raise IndexError('Index must be of type `int`/`slice` or an item name (`str`)')
         keys = list(self._kwargs.keys())
         return self._kwargs[keys[idx]]
 
@@ -185,14 +175,12 @@ class BaseCollection(BasedBase, MutableSequence):
             self._kwargs.update(update_dict)
             # ADD EDGE
             self._borg.map.add_edge(self, value)
-            self._borg.map.reset_type(value, "created_internal")
+            self._borg.map.reset_type(value, 'created_internal')
             value.interface = self.interface
             # REMOVE EDGE
             self._borg.map.prune_vertex_from_edge(self, old_item)
         else:
-            raise NotImplementedError(
-                "At the moment only numerical values or easyCore objects can be set."
-            )
+            raise NotImplementedError('At the moment only numerical values or easyCore objects can be set.')
 
     def __delitem__(self, key: int) -> None:
         """
@@ -217,9 +205,7 @@ class BaseCollection(BasedBase, MutableSequence):
         """
         return len(self._kwargs.keys())
 
-    def _convert_to_dict(
-        self, in_dict, encoder, skip: List[str] = [], **kwargs
-    ) -> dict:
+    def _convert_to_dict(self, in_dict, encoder, skip: List[str] = [], **kwargs) -> dict:
         """
         Convert ones self into a serialized form.
 
@@ -227,12 +213,10 @@ class BaseCollection(BasedBase, MutableSequence):
         :rtype: dict
         """
         d = {}
-        if hasattr(self, "_modify_dict"):
+        if hasattr(self, '_modify_dict'):
             # any extra keys defined on the inheriting class
             d = self._modify_dict(skip=skip, **kwargs)
-        in_dict["data"] = [
-            encoder._convert_to_dict(item, skip=skip, **kwargs) for item in self
-        ]
+        in_dict['data'] = [encoder._convert_to_dict(item, skip=skip, **kwargs) for item in self]
         out_dict = {**in_dict, **d}
         return out_dict
 
@@ -250,13 +234,9 @@ class BaseCollection(BasedBase, MutableSequence):
         return tuple(self._kwargs.values())
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__} `{getattr(self, 'name')}` of length {len(self)}"
-        )
+        return f"{self.__class__.__name__} `{getattr(self, 'name')}` of length {len(self)}"
 
-    def sort(
-        self, mapping: Callable[[Union[B, V]], Any], reverse: bool = False
-    ) -> None:
+    def sort(self, mapping: Callable[[Union[B, V]], Any], reverse: bool = False) -> None:
         """
         Sort the collection according to the given mapping.
 

--- a/easyCore/Objects/Groups.py
+++ b/easyCore/Objects/Groups.py
@@ -7,24 +7,25 @@ from __future__ import annotations
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
+from collections.abc import MutableSequence
 from numbers import Number
-from typing import (
-    Union,
-    Optional,
-    TYPE_CHECKING,
-    Callable,
-    List,
-    Any,
-    Tuple,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
 from easyCore import borg
-from easyCore.Objects.ObjectClasses import BasedBase, Descriptor
-from collections.abc import MutableSequence
+from easyCore.Objects.ObjectClasses import BasedBase
+from easyCore.Objects.ObjectClasses import Descriptor
 from easyCore.Utils.UndoRedo import NotarizedDict
 
 if TYPE_CHECKING:
-    from easyCore.Utils.typing import B, iF, V
+    from easyCore.Utils.typing import B
+    from easyCore.Utils.typing import V
+    from easyCore.Utils.typing import iF
 
 
 class BaseCollection(BasedBase, MutableSequence):

--- a/easyCore/Objects/Groups.py
+++ b/easyCore/Objects/Groups.py
@@ -10,12 +10,10 @@ __version__ = "0.1.0"
 from numbers import Number
 from typing import (
     Union,
-    TypeVar,
     Optional,
     TYPE_CHECKING,
     Callable,
     List,
-    Dict,
     Any,
     Tuple,
 )
@@ -147,7 +145,7 @@ class BaseCollection(BasedBase, MutableSequence):
             idx = [index for index, item in enumerate(self) if item.name == idx]
             l = len(idx)
             if l == 0:
-                raise IndexError(f"Given index does not exist")
+                raise IndexError("Given index does not exist")
             elif l == 1:
                 idx = idx[0]
             else:

--- a/easyCore/Objects/Inferface.py
+++ b/easyCore/Objects/Inferface.py
@@ -8,9 +8,13 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 from abc import ABCMeta
-from typing import TypeVar, List, NamedTuple, Callable, TYPE_CHECKING, Optional, Type
-
-
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import Type
+from typing import TypeVar
 
 _C = TypeVar("_C", bound=ABCMeta)
 _M = TypeVar("_M")

--- a/easyCore/Objects/Inferface.py
+++ b/easyCore/Objects/Inferface.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from typing import TypeVar, List, NamedTuple, Callable, TYPE_CHECKING, Optional, Type
 
-from easyCore import np
 
 
 _C = TypeVar("_C", bound=ABCMeta)

--- a/easyCore/Objects/ObjectClasses.py
+++ b/easyCore/Objects/ObjectClasses.py
@@ -7,12 +7,10 @@ __version__ = "0.1.0"
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
-import numbers
 from inspect import getfullargspec
 
 from typing import (
     List,
-    Union,
     Iterable,
     Dict,
     Optional,

--- a/easyCore/Objects/ObjectClasses.py
+++ b/easyCore/Objects/ObjectClasses.py
@@ -8,25 +8,26 @@ __version__ = "0.1.0"
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
 from inspect import getfullargspec
-
-from typing import (
-    List,
-    Iterable,
-    Dict,
-    Optional,
-    TypeVar,
-    TYPE_CHECKING,
-    Callable,
-    Set,
-)
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import TypeVar
 
 from easyCore import borg
-from .core import ComponentSerializer
 from easyCore.Utils.classTools import addLoggedProp
-from .Variable import Parameter, Descriptor
+
+from .core import ComponentSerializer
+from .Variable import Descriptor
+from .Variable import Parameter
 
 if TYPE_CHECKING:
-    from easyCore.Utils.typing import C, V, iF
+    from easyCore.Utils.typing import C
+    from easyCore.Utils.typing import V
+    from easyCore.Utils.typing import iF
 
 
 class BasedBase(ComponentSerializer):

--- a/easyCore/Objects/Variable.py
+++ b/easyCore/Objects/Variable.py
@@ -8,32 +8,32 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 import numbers
-import weakref
 import warnings
-
+import weakref
 from copy import deepcopy
 from inspect import getfullargspec
 from types import MappingProxyType
-from typing import (
-    List,
-    Union,
-    Any,
-    Dict,
-    Optional,
-    TYPE_CHECKING,
-    Callable,
-    Tuple,
-    TypeVar,
-    Type,
-    Set,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+from typing import Union
 
-from easyCore import borg, ureg, np, pint
+from easyCore import borg
+from easyCore import np
+from easyCore import pint
+from easyCore import ureg
+from easyCore.Fitting.Constraints import SelfConstraint
+from easyCore.Objects.core import ComponentSerializer
 from easyCore.Utils.classTools import addProp
 from easyCore.Utils.Exceptions import CoreSetException
 from easyCore.Utils.UndoRedo import property_stack_deco
-from easyCore.Objects.core import ComponentSerializer
-from easyCore.Fitting.Constraints import SelfConstraint
 
 if TYPE_CHECKING:
     from easyCore.Utils.typing import C

--- a/easyCore/Objects/Variable.py
+++ b/easyCore/Objects/Variable.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.1.0"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.1.0'
 
 import numbers
 import warnings
@@ -25,8 +25,9 @@ from typing import Type
 from typing import TypeVar
 from typing import Union
 
+import numpy as np
+
 from easyCore import borg
-from easyCore import np
 from easyCore import pint
 from easyCore import ureg
 from easyCore.Fitting.Constraints import SelfConstraint
@@ -56,11 +57,11 @@ class Descriptor(ComponentSerializer):
     _constructor = Q_
     _borg = borg
     _REDIRECT = {
-        "value": lambda obj: obj.raw_value,
-        "units": lambda obj: obj._args["units"],
-        "parent": None,
-        "callback": None,
-        "_finalizer": None,
+        'value': lambda obj: obj.raw_value,
+        'units': lambda obj: obj._args['units'],
+        'parent': None,
+        'callback': None,
+        '_finalizer': None,
     }
 
     def __init__(
@@ -104,11 +105,11 @@ class Descriptor(ComponentSerializer):
 
         .. note:: Undo/Redo functionality is implemented for the attributes `value`, `unit` and `display name`.
         """
-        if not hasattr(self, "_args"):
-            self._args = {"value": None, "units": ""}
+        if not hasattr(self, '_args'):
+            self._args = {'value': None, 'units': ''}
 
         # Let the collective know we've been assimilated
-        self._borg.map.add_vertex(self, obj_type="created")
+        self._borg.map.add_vertex(self, obj_type='created')
         # Make the connection between self and parent
         if parent is not None:
             self._borg.map.add_edge(parent, self)
@@ -126,20 +127,20 @@ class Descriptor(ComponentSerializer):
         self.__isBooleanValue = isinstance(value, bool)
         if self.__isBooleanValue:
             value = int(value)
-        self._args["value"] = value
-        self._args["units"] = str(self.unit)
+        self._args['value'] = value
+        self._args['units'] = str(self.unit)
         self._value = self.__class__._constructor(**self._args)
 
         self._enabled = enabled
 
         if description is None:
-            description = ""
+            description = ''
         self.description: str = description
 
         self._display_name: str = display_name
 
         if url is None:
-            url = ""
+            url = ''
 
         self.url: str = url
         if callback is None:
@@ -154,13 +155,13 @@ class Descriptor(ComponentSerializer):
 
     @property
     def _arg_spec(self) -> Set[str]:
-        base_cls = getattr(self, "__old_class__", self.__class__)
+        base_cls = getattr(self, '__old_class__', self.__class__)
         mro = base_cls.__mro__
         idx = mro.index(ComponentSerializer)
         names = set()
         for i in range(idx):
             cls = mro[i]
-            if hasattr(cls, "_CORE"):
+            if hasattr(cls, '_CORE'):
                 spec = getfullargspec(cls.__init__)
                 names = names.union(set(spec.args[1:]))
         return names
@@ -174,7 +175,7 @@ class Descriptor(ComponentSerializer):
         """
         state = self.encode()
         cls = self.__class__
-        if hasattr(self, "__old_class__"):
+        if hasattr(self, '__old_class__'):
             cls = self.__old_class__
         return cls.from_dict, (state,)
 
@@ -224,7 +225,7 @@ class Descriptor(ComponentSerializer):
             unit_str = str(unit_str)
         new_unit = ureg.parse_expression(unit_str)
         self._units = new_unit
-        self._args["units"] = str(new_unit)
+        self._args['units'] = str(new_unit)
         self._value = self.__class__._constructor(**self._args)
 
     @property
@@ -240,14 +241,14 @@ class Descriptor(ComponentSerializer):
         if self._callback.fget is not None:
             try:
                 value = self._callback.fget()
-                if hasattr(self._value, "magnitude"):
+                if hasattr(self._value, 'magnitude'):
                     if value != self._value.magnitude:
                         self.__deepValueSetter(value)
                 elif value != self._value:
                     self.__deepValueSetter(value)
 
             except Exception as e:
-                raise ValueError(f"Unable to return value:\n{e}")
+                raise ValueError(f'Unable to return value:\n{e}')
         r_value = self._value
         if self.__isBooleanValue:
             r_value = bool(r_value)
@@ -261,15 +262,15 @@ class Descriptor(ComponentSerializer):
         :return: None
         """
         # TODO there should be a callback to the collective, logging this as a return(if from a non `easyCore` class)
-        if hasattr(value, "magnitude"):
+        if hasattr(value, 'magnitude'):
             value = value.magnitude
-            if hasattr(value, "nominal_value"):
+            if hasattr(value, 'nominal_value'):
                 value = value.nominal_value
         self._type = type(value)
         self.__isBooleanValue = isinstance(value, bool)
         if self.__isBooleanValue:
             value = int(value)
-        self._args["value"] = value
+        self._args['value'] = value
         self._value = self.__class__._constructor(**self._args)
 
     @value.setter
@@ -283,7 +284,7 @@ class Descriptor(ComponentSerializer):
         """
         if not self.enabled:
             if borg.debug:
-                raise CoreSetException(f"{str(self)} is not enabled.")
+                raise CoreSetException(f'{str(self)} is not enabled.')
             return
         self.__deepValueSetter(value)
         if self._callback.fset is not None:
@@ -300,9 +301,9 @@ class Descriptor(ComponentSerializer):
         :return: The raw value of self
         """
         value = self._value
-        if hasattr(value, "magnitude"):
+        if hasattr(value, 'magnitude'):
             value = value.magnitude
-            if hasattr(value, "nominal_value"):
+            if hasattr(value, 'nominal_value'):
                 value = value.nominal_value
         if self.__isBooleanValue:
             value = bool(value)
@@ -337,8 +338,8 @@ class Descriptor(ComponentSerializer):
         new_unit = ureg.parse_expression(unit_str)
         self._value = self._value.to(new_unit)
         self._units = new_unit
-        self._args["value"] = self.raw_value
-        self._args["units"] = str(self.unit)
+        self._args['value'] = self.raw_value
+        self._args['units'] = str(self.unit)
 
     # @cached_property
     @property
@@ -359,10 +360,10 @@ class Descriptor(ComponentSerializer):
         else:
             obj_value = self._value.magnitude
         if isinstance(obj_value, float):
-            obj_value = "{:0.04f}".format(obj_value)
-        obj_units = ""
+            obj_value = '{:0.04f}'.format(obj_value)
+        obj_units = ''
         if not self.unit.dimensionless:
-            obj_units = " {:~P}".format(self.unit)
+            obj_units = ' {:~P}'.format(self.unit)
         out_str = f"<{class_name} '{obj_name}': {obj_value}{obj_units}>"
         return out_str
 
@@ -376,15 +377,15 @@ class Descriptor(ComponentSerializer):
         """
         pickled_obj = self.encode()
         pickled_obj.update(kwargs)
-        if "@class" in pickled_obj.keys():
-            pickled_obj["@class"] = data_type.__name__
+        if '@class' in pickled_obj.keys():
+            pickled_obj['@class'] = data_type.__name__
         return data_type.from_dict(pickled_obj)
 
     def __copy__(self):
         return self.__class__.from_dict(self.as_dict())
 
 
-V = TypeVar("V", bound=Descriptor)
+V = TypeVar('V', bound=Descriptor)
 
 
 class ComboDescriptor(Descriptor):
@@ -402,16 +403,14 @@ class ComboDescriptor(Descriptor):
         # We have initialized from the Descriptor class where value has it's own undo/redo decorator
         # This needs to be bypassed to use the Parameter undo/redo stack
         fun = self.__class__.value.fset
-        if hasattr(fun, "func"):
-            fun = getattr(fun, "func")
-        self.__previous_set: Callable[
-            [V, Union[numbers.Number, np.ndarray]], Union[numbers.Number, np.ndarray]
-        ] = fun
+        if hasattr(fun, 'func'):
+            fun = getattr(fun, 'func')
+        self.__previous_set: Callable[[V, Union[numbers.Number, np.ndarray]], Union[numbers.Number, np.ndarray]] = fun
 
         # Monkey patch the unit and the value to take into account the new max/min situation
         addProp(
             self,
-            "value",
+            'value',
             fget=self.__class__.value.fget,
             fset=self.__class__._property_value.fset,
             fdel=self.__class__.value.fdel,
@@ -453,17 +452,15 @@ class ComboDescriptor(Descriptor):
 
     @available_options.setter
     @property_stack_deco
-    def available_options(
-        self, available_options: List[Union[numbers.Number, np.ndarray, Q_]]
-    ) -> None:
+    def available_options(self, available_options: List[Union[numbers.Number, np.ndarray, Q_]]) -> None:
         self._available_options = available_options
 
     def as_dict(self, **kwargs) -> Dict[str, Any]:
         import json
 
         d = super().as_dict(**kwargs)
-        d["name"] = self.name
-        d["available_options"] = json.dumps(self.available_options)
+        d['name'] = self.name
+        d['available_options'] = json.dumps(self.available_options)
         return d
 
 
@@ -511,24 +508,24 @@ class Parameter(Descriptor):
             Undo/Redo functionality is implemented for the attributes `value`, `error`, `min`, `max`, `fixed`
         """
         # Set the error
-        self._args = {"value": value, "units": "", "error": error}
+        self._args = {'value': value, 'units': '', 'error': error}
 
         if not isinstance(value, numbers.Number):
-            raise ValueError("In a parameter the `value` must be numeric")
+            raise ValueError('In a parameter the `value` must be numeric')
         if value < min:
-            raise ValueError("`value` can not be less than `min`")
+            raise ValueError('`value` can not be less than `min`')
         if value > max:
-            raise ValueError("`value` can not be greater than `max`")
+            raise ValueError('`value` can not be greater than `max`')
         if error < 0:
-            raise ValueError("Standard deviation `error` must be positive")
+            raise ValueError('Standard deviation `error` must be positive')
 
         super().__init__(name, value, **kwargs)
-        self._args["units"] = str(self.unit)
+        self._args['units'] = str(self.unit)
 
         # Warnings if we are given a boolean
         if self._type == bool:
             warnings.warn(
-                "Boolean values are not officially supported in Parameter. Use a Descriptor instead",
+                'Boolean values are not officially supported in Parameter. Use a Descriptor instead',
                 UserWarning,
             )
 
@@ -538,12 +535,12 @@ class Parameter(Descriptor):
         self._fixed: bool = fixed
         self.initial_value = self.value
         self._constraints: dict = {
-            "user": {},
-            "builtin": {
-                "min": SelfConstraint(self, ">=", "_min"),
-                "max": SelfConstraint(self, "<=", "_max"),
+            'user': {},
+            'builtin': {
+                'min': SelfConstraint(self, '>=', '_min'),
+                'max': SelfConstraint(self, '<=', '_max'),
             },
-            "virtual": {},
+            'virtual': {},
         }
         # This is for the serialization. Otherwise we wouldn't catch the values given to `super()`
         self._kwargs = kwargs
@@ -551,8 +548,8 @@ class Parameter(Descriptor):
         # We have initialized from the Descriptor class where value has it's own undo/redo decorator
         # This needs to be bypassed to use the Parameter undo/redo stack
         fun = self.__class__.value.fset
-        if hasattr(fun, "func"):
-            fun = getattr(fun, "func")
+        if hasattr(fun, 'func'):
+            fun = getattr(fun, 'func')
         self.__previous_set: Callable[
             [V, Union[numbers.Number, np.ndarray]],
             Union[numbers.Number, np.ndarray],
@@ -561,7 +558,7 @@ class Parameter(Descriptor):
         # Monkey patch the unit and the value to take into account the new max/min situation
         addProp(
             self,
-            "value",
+            'value',
             fget=self.__class__.value.fget,
             fset=self.__class__._property_value.fset,
             fdel=self.__class__.value.fdel,
@@ -584,9 +581,7 @@ class Parameter(Descriptor):
             set_value = set_value.magnitude.nominal_value
         # Save the old state and create the new state
         old_value = self._value
-        self._value = self.__class__._constructor(
-            value=set_value, units=self._args["units"], error=self._args["error"]
-        )
+        self._value = self.__class__._constructor(value=set_value, units=self._args['units'], error=self._args['error'])
 
         # First run the built in constraints. i.e. min/max
         constraint_type: MappingProxyType[str, C] = self.builtin_constraints
@@ -602,7 +597,7 @@ class Parameter(Descriptor):
             self._borg.stack.force_state(state)
 
         # And finally update any virtual constraints
-        constraint_type: dict = self._constraints["virtual"]
+        constraint_type: dict = self._constraints['virtual']
         _ = self.__constraint_runner(constraint_type, new_value)
 
         # Restore to the old state
@@ -616,14 +611,14 @@ class Parameter(Descriptor):
         :param new_unit: new unit
         :return: None
         """
-        old_unit = str(self._args["units"])
+        old_unit = str(self._args['units'])
         super().convert_unit(new_unit)
         # Deal with min/max. Error is auto corrected
-        if not self.value.unitless and old_unit != "dimensionless":
+        if not self.value.unitless and old_unit != 'dimensionless':
             self._min = Q_(self.min, old_unit).to(self._units).magnitude
             self._max = Q_(self.max, old_unit).to(self._units).magnitude
         # Log the new converted error
-        self._args["error"] = self.value.error.magnitude
+        self._args['error'] = self.value.error.magnitude
 
     @property
     def min(self) -> numbers.Number:
@@ -647,9 +642,7 @@ class Parameter(Descriptor):
         if value <= self.raw_value:
             self._min = value
         else:
-            raise ValueError(
-                f"The current set value ({self.raw_value}) is less than the desired min value ({value})."
-            )
+            raise ValueError(f'The current set value ({self.raw_value}) is less than the desired min value ({value}).')
 
     @property
     def max(self) -> numbers.Number:
@@ -673,9 +666,7 @@ class Parameter(Descriptor):
         if value >= self.raw_value:
             self._max = value
         else:
-            raise ValueError(
-                f"The current set value ({self.raw_value}) is greater than the desired max value ({value})."
-            )
+            raise ValueError(f'The current set value ({self.raw_value}) is greater than the desired max value ({value}).')
 
     @property
     def fixed(self) -> bool:
@@ -701,7 +692,7 @@ class Parameter(Descriptor):
             if self._borg.stack.enabled:
                 self._borg.stack.pop()
             if borg.debug:
-                raise CoreSetException(f"{str(self)} is not enabled.")
+                raise CoreSetException(f'{str(self)} is not enabled.')
             return
         # TODO Should we try and cast value to bool rather than throw ValueError?
         if not isinstance(value, bool):
@@ -729,7 +720,7 @@ class Parameter(Descriptor):
         """
         if value < 0:
             raise ValueError
-        self._args["error"] = value
+        self._args['error'] = value
         self._value = self.__class__._constructor(**self._args)
 
     def __repr__(self) -> str:
@@ -740,10 +731,10 @@ class Parameter(Descriptor):
         super_str = super_str[:-1]
         s = []
         if self.fixed:
-            super_str += " (fixed)"
+            super_str += ' (fixed)'
         s.append(super_str)
-        s.append("bounds=[%s:%s]" % (repr(self.min), repr(self.max)))
-        return "%s>" % ", ".join(s)
+        s.append('bounds=[%s:%s]' % (repr(self.min), repr(self.max)))
+        return '%s>' % ', '.join(s)
 
     def __float__(self) -> float:
         return float(self.raw_value)
@@ -755,7 +746,7 @@ class Parameter(Descriptor):
 
         :return: Dictionary of constraints which are built into the system
         """
-        return MappingProxyType(self._constraints["builtin"])
+        return MappingProxyType(self._constraints['builtin'])
 
     @property
     def user_constraints(self) -> Dict[str, C]:
@@ -764,11 +755,11 @@ class Parameter(Descriptor):
 
         :return: Dictionary of constraints which are user supplied
         """
-        return self._constraints["user"]
+        return self._constraints['user']
 
     @user_constraints.setter
     def user_constraints(self, constraints_dict: Dict[str, C]) -> None:
-        self._constraints["user"] = constraints_dict
+        self._constraints['user'] = constraints_dict
 
     def _quick_set(
         self,
@@ -799,12 +790,12 @@ class Parameter(Descriptor):
                 self._borg.stack.force_state(state)
         if run_virtual_constraints:
             # And finally update any virtual constraints
-            constraint_type: dict = self._constraints["virtual"]
+            constraint_type: dict = self._constraints['virtual']
             _ = self.__constraint_runner(constraint_type, set_value)
 
         # Finally set the value
         self._property_value._magnitude._nominal_value = set_value
-        self._args["value"] = set_value
+        self._args['value'] = set_value
         if self._callback.fset is not None:
             self._callback.fset(set_value)
 
@@ -820,11 +811,11 @@ class Parameter(Descriptor):
             this_new_value = constraint(no_set=True)
             if this_new_value != newer_value:
                 if borg.debug:
-                    print(f"Constraint `{constraint}` has been applied")
+                    print(f'Constraint `{constraint}` has been applied')
                 self._value = self.__class__._constructor(
                     value=this_new_value,
-                    units=self._args["units"],
-                    error=self._args["error"],
+                    units=self._args['units'],
+                    error=self._args['error'],
                 )
             newer_value = this_new_value
         return newer_value
@@ -839,9 +830,7 @@ class Parameter(Descriptor):
         return self._min, self._max
 
     @bounds.setter
-    def bounds(
-        self, new_bound: Union[Tuple[numbers.Number, numbers.Number], numbers.Number]
-    ) -> None:
+    def bounds(self, new_bound: Union[Tuple[numbers.Number, numbers.Number], numbers.Number]) -> None:
         """
         Set the bounds of the parameter. *This will also enable the parameter*.
 
@@ -851,7 +840,7 @@ class Parameter(Descriptor):
         # Macro checking and opening for undo/redo
         close_macro = False
         if self._borg.stack.enabled:
-            self._borg.stack.beginMacro("Setting bounds")
+            self._borg.stack.beginMacro('Setting bounds')
             close_macro = True
         # Have we only been given a single number (MIN)?
         if isinstance(new_bound, numbers.Number):

--- a/easyCore/Objects/core.py
+++ b/easyCore/Objects/core.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 __author__ = "github.com/wardsimon"
 __version__ = "0.0.1"
 
-from typing import Optional, List, Dict, Any, TYPE_CHECKING, Set, Type
+from typing import Optional, List, Dict, Any, TYPE_CHECKING
 from hashlib import sha1
 import json
 from easyCore.Utils.io.dict import DictSerializer, DataDictSerializer

--- a/easyCore/Objects/core.py
+++ b/easyCore/Objects/core.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.0.1"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.0.1'
 
 import json
 from collections import OrderedDict
@@ -32,9 +32,7 @@ class ComponentSerializer:
 
     _CORE = True
 
-    def encode(
-        self, skip: Optional[List[str]] = None, encoder: Optional[EC] = None, **kwargs
-    ) -> Any:
+    def encode(self, skip: Optional[List[str]] = None, encoder: Optional[EC] = None, **kwargs) -> Any:
         """
         Use an encoder to covert an easyCore object into another format. Default is to a dictionary using `DictSerializer`.
 
@@ -85,9 +83,7 @@ class ComponentSerializer:
 
         return cls.decode(obj_dict, decoder=DictSerializer)
 
-    def encode_data(
-        self, skip: Optional[List[str]] = None, encoder: Optional[EC] = None, **kwargs
-    ) -> Any:
+    def encode_data(self, skip: Optional[List[str]] = None, encoder: Optional[EC] = None, **kwargs) -> Any:
         """
         Returns just the data in an easyCore object win the format specified by an encoder.
 
@@ -118,31 +114,21 @@ class ComponentSerializer:
         any nested keys, and then performing a hash on the resulting object
         """
 
-        def flatten(obj, seperator="."):
+        def flatten(obj, seperator='.'):
             # Flattens a dictionary
 
             flat_dict = {}
             for key, value in obj.items():
                 if isinstance(value, dict):
-                    flat_dict.update(
-                        {
-                            seperator.join([key, _key]): _value
-                            for _key, _value in flatten(value).items()
-                        }
-                    )
+                    flat_dict.update({seperator.join([key, _key]): _value for _key, _value in flatten(value).items()})
                 elif isinstance(value, list):
-                    list_dict = {
-                        "{}{}{}".format(key, seperator, num): item
-                        for num, item in enumerate(value)
-                    }
+                    list_dict = {'{}{}{}'.format(key, seperator, num): item for num, item in enumerate(value)}
                     flat_dict.update(flatten(list_dict))
                 else:
                     flat_dict[key] = value
 
             return flat_dict
 
-        ordered_keys = sorted(
-            flatten(jsanitize(self.as_dict())).items(), key=lambda x: x[0]
-        )
-        ordered_keys = [item for item in ordered_keys if "@" not in item[0]]
-        return sha1(json.dumps(OrderedDict(ordered_keys)).encode("utf-8"))  # nosec
+        ordered_keys = sorted(flatten(jsanitize(self.as_dict())).items(), key=lambda x: x[0])
+        ordered_keys = [item for item in ordered_keys if '@' not in item[0]]
+        return sha1(json.dumps(OrderedDict(ordered_keys)).encode('utf-8'))  # noqa: S324

--- a/easyCore/Objects/core.py
+++ b/easyCore/Objects/core.py
@@ -7,12 +7,18 @@ from __future__ import annotations
 __author__ = "github.com/wardsimon"
 __version__ = "0.0.1"
 
-from typing import Optional, List, Dict, Any, TYPE_CHECKING
-from hashlib import sha1
 import json
-from easyCore.Utils.io.dict import DictSerializer, DataDictSerializer
-from easyCore.Utils.io.json import jsanitize
 from collections import OrderedDict
+from hashlib import sha1
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from easyCore.Utils.io.dict import DataDictSerializer
+from easyCore.Utils.io.dict import DictSerializer
+from easyCore.Utils.io.json import jsanitize
 
 if TYPE_CHECKING:
     from easyCore.Utils.io.template import EC

--- a/easyCore/Objects/virtual.py
+++ b/easyCore/Objects/virtual.py
@@ -10,7 +10,9 @@ __version__ = "0.0.1"
 import inspect
 import weakref
 from copy import deepcopy
-from typing import Iterable, MutableSequence, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from typing import Iterable
+from typing import MutableSequence
 
 from easyCore import borg
 from easyCore.Fitting.Constraints import ObjConstraint

--- a/easyCore/Objects/virtual.py
+++ b/easyCore/Objects/virtual.py
@@ -10,7 +10,7 @@ __version__ = "0.0.1"
 import inspect
 import weakref
 from copy import deepcopy
-from typing import Iterable, MutableSequence, TYPE_CHECKING, TypeVar
+from typing import Iterable, MutableSequence, TYPE_CHECKING
 
 from easyCore import borg
 from easyCore.Fitting.Constraints import ObjConstraint

--- a/easyCore/Utils/Hugger/Hugger.py
+++ b/easyCore/Utils/Hugger/Hugger.py
@@ -7,8 +7,10 @@ __version__ = "0.1.0"
 
 import inspect
 import sys
-from typing import Tuple, List
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
+from abc import abstractmethod
+from typing import List
+from typing import Tuple
 
 from easyCore.Utils.classUtils import singleton
 

--- a/easyCore/Utils/Hugger/Hugger.py
+++ b/easyCore/Utils/Hugger/Hugger.py
@@ -5,17 +5,12 @@
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
-import weakref
 import inspect
 import sys
 from typing import Tuple, List
-from collections.abc import Callable
 from abc import ABCMeta, abstractmethod
-from functools import wraps
-from types import MethodType
 
 from easyCore.Utils.classUtils import singleton
-from collections.abc import Mapping
 
 
 @singleton

--- a/easyCore/Utils/Hugger/Property.py
+++ b/easyCore/Utils/Hugger/Property.py
@@ -6,12 +6,14 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 import sys
-
-from typing import Callable, List, Any
 from functools import wraps
+from typing import Any
+from typing import Callable
+from typing import List
 
 from easyCore import borg
-from easyCore.Utils.Hugger.Hugger import Store, PatcherFactory
+from easyCore.Utils.Hugger.Hugger import PatcherFactory
+from easyCore.Utils.Hugger.Hugger import Store
 
 
 class LoggedProperty(property):

--- a/easyCore/Utils/UndoRedo.py
+++ b/easyCore/Utils/UndoRedo.py
@@ -7,10 +7,17 @@ __version__ = "0.1.0"
 
 import abc
 import functools
-from collections import deque, UserDict
-from typing import Union, Any, NoReturn, Callable, TypeVar, Iterable
+from collections import UserDict
+from collections import deque
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import NoReturn
+from typing import TypeVar
+from typing import Union
 
-from easyCore import borg, np
+from easyCore import borg
+from easyCore import np
 
 
 class UndoCommand(metaclass=abc.ABCMeta):

--- a/easyCore/Utils/UndoRedo.py
+++ b/easyCore/Utils/UndoRedo.py
@@ -2,8 +2,8 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.1.0"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.1.0'
 
 import abc
 import functools
@@ -16,8 +16,9 @@ from typing import NoReturn
 from typing import TypeVar
 from typing import Union
 
+import numpy as np
+
 from easyCore import borg
-from easyCore import np
 
 
 class UndoCommand(metaclass=abc.ABCMeta):
@@ -50,13 +51,13 @@ class UndoCommand(metaclass=abc.ABCMeta):
         self._text = text
 
 
-T_ = TypeVar("T_", bound=UndoCommand)
+T_ = TypeVar('T_', bound=UndoCommand)
 
 
 def dict_stack_deco(func: Callable) -> Callable:
     def inner(obj, *args, **kwargs):
         # Only do the work to a NotarizedDict.
-        if hasattr(obj, "_stack_enabled") and obj._stack_enabled:
+        if hasattr(obj, '_stack_enabled') and obj._stack_enabled:
             if not kwargs:
                 borg.stack.push(DictStack(obj, *args))
             else:
@@ -91,7 +92,7 @@ class NotarizedDict(UserDict):
         super(NotarizedDict, self).__delitem__(key)
 
     def __repr__(self):
-        return f"{self._classname()}({self.data})"
+        return f'{self._classname()}({self.data})'
 
     @dict_stack_deco
     def reorder(self, **kwargs):
@@ -109,7 +110,6 @@ class CommandHolder:
         self.__index = 0
 
     def append(self, command: T_):
-
         self._commands.appendleft(command)
 
     def pop(self):
@@ -135,7 +135,7 @@ class CommandHolder:
 
     @property
     def text(self) -> str:
-        text = ""
+        text = ''
         if self._commands:
             text = self._commands[-1].text
         if self._text is not None:
@@ -250,7 +250,6 @@ class UndoStack:
         Redo the last `undo` command on the stack
         """
         if self.canRedo():
-
             # Move from the future to the past
             this_command_stack = self._future.popleft()
             self._history.appendleft(this_command_stack)
@@ -271,7 +270,7 @@ class UndoStack:
         Start a bulk update i.e. multiple commands under one undo/redo command
         """
         if self._macro_running:
-            raise AssertionError("Cannot start a macro when one is already running")
+            raise AssertionError('Cannot start a macro when one is already running')
         com = CommandHolder(text)
         self.history.appendleft(com)
         self._macro_running = True
@@ -281,7 +280,7 @@ class UndoStack:
         End a bulk update i.e. multiple commands under one undo/redo command
         """
         if not self._macro_running:
-            raise AssertionError("Cannot end a macro when one is not running")
+            raise AssertionError('Cannot end a macro when one is not running')
         self._macro_running = False
 
     def canUndo(self) -> bool:
@@ -300,7 +299,7 @@ class UndoStack:
         """
         Text associated with a redo item.
         """
-        text = ""
+        text = ''
         if self.canRedo():
             text = self.future[0].text
         return text
@@ -309,7 +308,7 @@ class UndoStack:
         """
         Text associated with a undo item.
         """
-        text = ""
+        text = ''
         if self.canUndo():
             text = self.history[0].text
         return text
@@ -320,16 +319,14 @@ class PropertyStack(UndoCommand):
     Stack operator for when a property setter is wrapped.
     """
 
-    def __init__(
-        self, parent, func: Callable, old_value: Any, new_value: Any, text: str = None
-    ):
+    def __init__(self, parent, func: Callable, old_value: Any, new_value: Any, text: str = None):
         # self.setText("Setting {} to {}".format(func.__name__, new_value))
         super().__init__(self)
         self._parent = parent
         self._old_value = old_value
         self._new_value = new_value
         self._set_func = func
-        self.text = f"{parent} value changed from {old_value} to {new_value}"
+        self.text = f'{parent} value changed from {old_value} to {new_value}'
         if text is not None:
             self.text = text
 
@@ -341,14 +338,12 @@ class PropertyStack(UndoCommand):
 
 
 class FunctionStack(UndoCommand):
-    def __init__(
-        self, parent, set_func: Callable, unset_func: Callable, text: str = None
-    ):
+    def __init__(self, parent, set_func: Callable, unset_func: Callable, text: str = None):
         super().__init__(self)
         self._parent = parent
         self._old_fn = set_func
         self._new_fn = unset_func
-        self.text = f"{parent} called {set_func}"
+        self.text = f'{parent} called {set_func}'
         if text is not None:
             self.text = text
 
@@ -371,7 +366,7 @@ class DictStack(UndoCommand):
         self._index = None
         self._old_value = None
         self._new_value = None
-        self.text = ""
+        self.text = ''
 
         if len(args) == 1:
             # We are deleting
@@ -379,7 +374,7 @@ class DictStack(UndoCommand):
             self._index = list(self._parent.keys()).index(args[0])
             self._old_value = self._parent[args[0]]
             self._key = args[0]
-            self.text = f"Deleting {args[0]} from {self._parent}"
+            self.text = f'Deleting {args[0]} from {self._parent}'
         elif len(args) == 2:
             # We are either creating or setting
             self._key = args[0]
@@ -387,12 +382,10 @@ class DictStack(UndoCommand):
             if self._key in self._parent.keys():
                 # We are modifying
                 self._old_value = self._parent[self._key]
-                self.text = f"Setting {self._parent}[{self._key}] from {self._old_value} to {self._new_value}"
+                self.text = f'Setting {self._parent}[{self._key}] from {self._old_value} to {self._new_value}'
             else:
                 self._creation = True
-                self.text = (
-                    f"Creating {self._parent}[{self._key}] with value {self._new_value}"
-                )
+                self.text = f'Creating {self._parent}[{self._key}] with value {self._new_value}'
         else:
             raise ValueError
 
@@ -426,7 +419,7 @@ class DictStackReCreate(UndoCommand):
         self._parent = in_dict
         self._old_value = in_dict.data.copy()
         self._new_value = kwargs
-        self.text = "Updating dictionary"
+        self.text = 'Updating dictionary'
 
     def undo(self) -> NoReturn:
         self._parent.data = self._old_value
@@ -435,9 +428,7 @@ class DictStackReCreate(UndoCommand):
         self._parent.data = self._new_value
 
 
-def property_stack_deco(
-    arg: Union[str, Callable], begin_macro: bool = False
-) -> Callable:
+def property_stack_deco(arg: Union[str, Callable], begin_macro: bool = False) -> Callable:
     """
     Decorate a `property` setter with undo/redo functionality
     This decorator can be used as:
@@ -469,9 +460,7 @@ def property_stack_deco(
         def wrapper(obj, *args) -> NoReturn:
             old_value = getattr(obj, name)
             new_value = args[0]
-            if issubclass(type(old_value), Iterable) or issubclass(
-                type(new_value), Iterable
-            ):
+            if issubclass(type(old_value), Iterable) or issubclass(type(new_value), Iterable):
                 ret = np.all(old_value == new_value)
             else:
                 ret = old_value == new_value
@@ -489,14 +478,14 @@ def property_stack_deco(
         func = arg
         name = func.__name__
         wrapper = make_wrapper(func, name)
-        setattr(wrapper, "func", func)
+        setattr(wrapper, 'func', func)
     else:
         txt = arg
 
         def wrapper(func: Callable) -> Callable:
             name = func.__name__
             inner_wrapper = make_wrapper(func, name, text=txt.format(**locals()))
-            setattr(inner_wrapper, "func", func)
+            setattr(inner_wrapper, 'func', func)
             return inner_wrapper
 
     return wrapper

--- a/easyCore/Utils/classTools.py
+++ b/easyCore/Utils/classTools.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
-from typing import List, Tuple, TYPE_CHECKING, TypeVar, Union
+from typing import List, Tuple, TYPE_CHECKING
 
 from easyCore import borg
 from easyCore.Utils.Hugger.Property import LoggedProperty

--- a/easyCore/Utils/classTools.py
+++ b/easyCore/Utils/classTools.py
@@ -7,13 +7,16 @@ from __future__ import annotations
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
-from typing import List, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from typing import List
+from typing import Tuple
 
 from easyCore import borg
 from easyCore.Utils.Hugger.Property import LoggedProperty
 
 if TYPE_CHECKING:
-    from easyCore.Utils.typing import B, BV
+    from easyCore.Utils.typing import BV
+    from easyCore.Utils.typing import B
 
 
 def addLoggedProp(inst: BV, name: str, *args, **kwargs) -> None:

--- a/easyCore/Utils/decorators.py
+++ b/easyCore/Utils/decorators.py
@@ -8,7 +8,6 @@ __version__ = "0.1.0"
 import collections.abc
 import functools
 import warnings
-
 from time import time
 
 from easyCore import borg

--- a/easyCore/Utils/io/dict.py
+++ b/easyCore/Utils/io/dict.py
@@ -7,7 +7,11 @@ __version__ = "3.0.0"
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
 
-from typing import Optional, List, Dict, Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 
 from easyCore.Utils.io.template import BaseEncoderDecoder
 

--- a/easyCore/Utils/io/json.py
+++ b/easyCore/Utils/io/json.py
@@ -9,11 +9,11 @@ __version__ = "3.0.0"
 
 
 import json
-
-from typing import List, TYPE_CHECKING
-
+from typing import TYPE_CHECKING
+from typing import List
 
 from easyCore import np
+
 from .template import BaseEncoderDecoder
 
 if TYPE_CHECKING:

--- a/easyCore/Utils/io/json.py
+++ b/easyCore/Utils/io/json.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-__author__ = "https://github.com/materialsvirtuallab/monty/blob/master/monty/json.py"
-__version__ = "3.0.0"
+__author__ = 'https://github.com/materialsvirtuallab/monty/blob/master/monty/json.py'
+__version__ = '3.0.0'
 
 #  SPDX-FileCopyrightText: 2023 easyCore contributors  <core@easyscience.software>
 #  SPDX-License-Identifier: BSD-3-Clause
@@ -12,14 +12,14 @@ import json
 from typing import TYPE_CHECKING
 from typing import List
 
-from easyCore import np
+import numpy as np
 
 from .template import BaseEncoderDecoder
 
 if TYPE_CHECKING:
     from easyCore.Objects.ObjectClasses import BV
 
-_KNOWN_CORE_TYPES = ("Descriptor", "Parameter")
+_KNOWN_CORE_TYPES = ('Descriptor', 'Parameter')
 
 
 class JsonSerializer(BaseEncoderDecoder):
@@ -30,7 +30,7 @@ class JsonSerializer(BaseEncoderDecoder):
         ENCODER = type(
             JsonEncoderTemplate.__name__,
             (JsonEncoderTemplate, BaseEncoderDecoder),
-            {"skip": skip},
+            {'skip': skip},
         )
         return json.dumps(obj, cls=ENCODER)
 
@@ -50,8 +50,8 @@ class JsonDataSerializer(BaseEncoderDecoder):
             JsonEncoderTemplate.__name__,
             (JsonEncoderTemplate, BaseEncoderDecoder),
             {
-                "skip": skip,
-                "_converter": lambda *args, **kwargs: DataDictSerializer._parse_dict(
+                'skip': skip,
+                '_converter': lambda *args, **kwargs: DataDictSerializer._parse_dict(
                     DataDictSerializer._convert_to_dict(*args, **kwargs)
                 ),
             },
@@ -61,9 +61,7 @@ class JsonDataSerializer(BaseEncoderDecoder):
 
     @classmethod
     def decode(cls, data: str) -> BV:
-        raise NotImplementedError(
-            "It is not possible to reconstitute objects from data only objects."
-        )
+        raise NotImplementedError('It is not possible to reconstitute objects from data only objects.')
 
 
 class JsonEncoderTemplate(json.JSONEncoder):
@@ -156,14 +154,9 @@ def jsanitize(obj, strict=False, allow_bson=False):
     if isinstance(obj, (list, tuple)):
         return [jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj]
     if np is not None and isinstance(obj, np.ndarray):
-        return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj.tolist()
-        ]
+        return [jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj.tolist()]
     if isinstance(obj, dict):
-        return {
-            k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson)
-            for k, v in obj.items()
-        }
+        return {k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson) for k, v in obj.items()}
     if isinstance(obj, (int, float)):
         return obj
     if obj is None:

--- a/easyCore/Utils/io/json.py
+++ b/easyCore/Utils/io/json.py
@@ -10,7 +10,7 @@ __version__ = "3.0.0"
 
 import json
 
-from typing import Optional, List, Dict, Any, TYPE_CHECKING
+from typing import List, TYPE_CHECKING
 
 
 from easyCore import np

--- a/easyCore/Utils/io/star.py
+++ b/easyCore/Utils/io/star.py
@@ -8,9 +8,10 @@ __version__ = "0.1.0"
 import re
 import textwrap
 import warnings
-
-from collections import deque, OrderedDict
-from math import floor, log10
+from collections import OrderedDict
+from collections import deque
+from math import floor
+from math import log10
 from numbers import Number
 from typing import List
 

--- a/easyCore/Utils/io/star.py
+++ b/easyCore/Utils/io/star.py
@@ -2,8 +2,8 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.1.0"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.1.0'
 
 import re
 import textwrap
@@ -40,24 +40,23 @@ class FakeCore:
 
 class ItemHolder:
     def __init__(self, item, decimal_places: int = 8):
-
         self.maxlen = _MAX_LEN
 
         self.value = item.raw_value
         self.fixed = None
         self.error = None
         self.decimal_places = decimal_places
-        if hasattr(item, "fixed"):
+        if hasattr(item, 'fixed'):
             self.fixed = item.fixed
             if item.error != 0:
                 self.error = item.error
 
     def _get_error_digits(self) -> int:
-        return len(f"{round(self.error, self.decimal_places)}".split(".")[-1])
+        return len(f'{round(self.error, self.decimal_places)}'.split('.')[-1])
 
     def __str__(self) -> str:
         if isinstance(self.value, Number):
-            initial_str = "{:." + str(self.decimal_places) + "f}"
+            initial_str = '{:.' + str(self.decimal_places) + 'f}'
             s = initial_str.format(round(self.value, self.decimal_places))
             if self.error is not None:
                 # x_exp = int(floor(log10(self.value)))
@@ -72,15 +71,15 @@ class ItemHolder:
                 no_int = round(self.value * 10 ** (-no_exp))
 
                 # format - nom(unc)
-                fmt = "%%.%df" % max(0, -no_exp)
-                s = (fmt + "(%.0f)") % (
+                fmt = '%%.%df' % max(0, -no_exp)
+                s = (fmt + '(%.0f)') % (
                     no_int * 10**no_exp,
                     un_int * 10 ** max(0, un_exp),
                 )
         elif isinstance(self.value, str):
-            s = "{:s}".format(self.value)
+            s = '{:s}'.format(self.value)
         else:
-            s = "{:s}".format(str(self.value))
+            s = '{:s}'.format(str(self.value))
         # THIS IS THE OLD CODE, KEPT FOR REFERENCE
         # s = "{}"
         # if isinstance(self.value, str):
@@ -97,21 +96,17 @@ class ItemHolder:
         #         s = "{" + f":0.0{digits}f" + "}({})"
         #     s = s.format(*v_in)
         if self.fixed is not None and not self.fixed and self.error is None:
-            s += "()"
+            s += '()'
         return self._format_field(s)
 
     def _format_field(self, v):
         v = v.__str__().strip()
         if len(v) > self.maxlen:
-            return ";\n" + textwrap.fill(v, self.maxlen) + "\n;"
+            return ';\n' + textwrap.fill(v, self.maxlen) + '\n;'
         # add quotes if necessary
-        if v == "":
+        if v == '':
             return '""'
-        if (
-            (" " in v or v[0] == "_")
-            and not (v[0] == "'" and v[-1] == "'")
-            and not (v[0] == '"' and v[-1] == '"')
-        ):
+        if (' ' in v or v[0] == '_') and not (v[0] == "'" and v[-1] == "'") and not (v[0] == '"' and v[-1] == '"'):
             if "'" in v:
                 q = '"'
             else:
@@ -123,10 +118,10 @@ class ItemHolder:
     def _makeFakeItem(in_string: str) -> FakeItem:
         in_string = in_string.strip()
         if "'" in in_string:
-            in_string = in_string.replace("'", "")
+            in_string = in_string.replace("'", '')
         fixed = None
         error = None
-        tokens = in_string.split("(")
+        tokens = in_string.split('(')
         try:
             value = float(tokens[0])
         except ValueError:
@@ -134,10 +129,8 @@ class ItemHolder:
             return FakeItem(value, error, fixed)
         if len(tokens) > 1:
             fixed = False
-            if tokens[1][0] != ")":
-                error = (
-                    10 ** -(len(f"{tokens[0]}".split(".")[1]) + len(tokens[1][:-1]) - 1)
-                ) * int(tokens[1][:-1])
+            if tokens[1][0] != ')':
+                error = (10 ** -(len(f'{tokens[0]}'.split('.')[1]) + len(tokens[1][:-1]) - 1)) * int(tokens[1][:-1])
         return FakeItem(value, error, fixed)
 
     @classmethod
@@ -149,25 +142,24 @@ class ItemHolder:
 
 
 class StarEntry(ItemHolder):
-    def __init__(self, item, entry_name: str = None, prefix="_"):
-
+    def __init__(self, item, entry_name: str = None, prefix='_'):
         if entry_name is None:
             entry_name = item.name
 
         if len(entry_name) > _MAX_LABEL_LEN:
-            raise AttributeError(f"Max label length is {int(_MAX_LABEL_LEN)}")
+            raise AttributeError(f'Max label length is {int(_MAX_LABEL_LEN)}')
 
         self.name = entry_name
         self.prefix = prefix
         super(StarEntry, self).__init__(item)
 
     def __str__(self) -> str:
-        s = "{}{}   ".format(self.prefix, self.name) + super(StarEntry, self).__str__()
+        s = '{}{}   '.format(self.prefix, self.name) + super(StarEntry, self).__str__()
         return s
 
     @classmethod
-    def from_string(cls, input_str: str, name_conversion: str = None, prefix="_"):
-        name, value = input_str.split("   ")
+    def from_string(cls, input_str: str, name_conversion: str = None, prefix='_'):
+        name, value = input_str.split('   ')
         name = name[len(prefix) :]
         if name_conversion:
             name = name_conversion
@@ -176,12 +168,12 @@ class StarEntry(ItemHolder):
     def to_class(self, cls, name_conversion: str = None):
         if name_conversion is None:
             name_conversion = self.name
-        if hasattr(cls, "from_pars"):
+        if hasattr(cls, 'from_pars'):
             new_obj = cls.from_pars(**{name_conversion: self.value})
-        if hasattr(new_obj, "fixed"):
+        if hasattr(new_obj, 'fixed'):
             if self.fixed is not None:
                 new_obj.fixed = self.fixed
-        if hasattr(new_obj, "error"):
+        if hasattr(new_obj, 'error'):
             if self.error is not None:
                 new_obj.error = self.error
         return new_obj
@@ -191,9 +183,9 @@ class StarProcess:
     @classmethod
     def _process_string(cls, string):
         # remove comments
-        string = re.sub(r"(\s|^)#.*$", "", string, flags=re.MULTILINE)
+        string = re.sub(r'(\s|^)#.*$', '', string, flags=re.MULTILINE)
         # remove empty lines
-        string = re.sub(r"^\s*\n", "", string, flags=re.MULTILINE)
+        string = re.sub(r'^\s*\n', '', string, flags=re.MULTILINE)
         # remove non_ascii
         # string = remove_non_ascii(string)
         # since line breaks in .cif files are mostly meaningless,
@@ -207,67 +199,65 @@ class StarProcess:
         # (these get eaten by the first expression)
         # ending quotes must not be followed by non-whitespace
         p = re.compile(r"""([^'"\s][\S]*)|'(.*?)'(?!\S)|"(.*?)"(?!\S)""")
-        for l in string.splitlines():
+        for line in string.splitlines():
             if multiline:
-                if l.startswith(";"):
+                if line.startswith(';'):
                     multiline = False
-                    q.append(("", "", "", " ".join(ml)))
+                    q.append(('', '', '', ' '.join(ml)))
                     ml = []
-                    l = l[1:].strip()
+                    line = line[1:].strip()
                 else:
-                    ml.append(l)
+                    ml.append(line)
                     continue
-            if l.startswith(";"):
+            if line.startswith(';'):
                 multiline = True
-                ml.append(l[1:].strip())
+                ml.append(line[1:].strip())
             else:
-                for s in p.findall(l):
+                for s in p.findall(line):
                     # s is tuple. location of the data in the tuple
                     # depends on whether it was quoted in the input
                     q.append(s)
         return q
 
     @classmethod
-    def _loadBlock(cls, in_string: str, prefix="_"):
+    def _loadBlock(cls, in_string: str, prefix='_'):
         q = cls._process_string(in_string)
         data = OrderedDict()
         loops = []
         while q:
             s = q.popleft()
             # cif keys aren't in quotes, so show up in s[0]
-            if s[0] == "_eof":
+            if s[0] == '_eof':
                 break
             if s[0].startswith(prefix):
                 try:
-                    data[s[0]] = "".join(q.popleft())
+                    data[s[0]] = ''.join(q.popleft())
                 except IndexError:
-                    data[s[0]] = ""
-            elif s[0].startswith("loop_"):
+                    data[s[0]] = ''
+            elif s[0].startswith('loop_'):
                 columns = []
                 items = []
                 this_data = OrderedDict()
                 while q:
                     s = q[0]
-                    if s[0].startswith("loop_") or not s[0].startswith(prefix):
+                    if s[0].startswith('loop_') or not s[0].startswith(prefix):
                         break
-                    columns.append("".join(q.popleft()))
+                    columns.append(''.join(q.popleft()))
                     this_data[columns[-1]] = []
                 while q:
                     s = q[0]
-                    if s[0].startswith("loop_") or s[0].startswith(prefix):
+                    if s[0].startswith('loop_') or s[0].startswith(prefix):
                         break
-                    items.append("".join(q.popleft()))
+                    items.append(''.join(q.popleft()))
                 n = len(items) // len(columns)
-                assert len(items) % n == 0
+                if len(items) % n != 0:
+                    raise ValueError('Wrong dimensions in loop_ block')
                 # loops.append(columns)
                 for k, v in zip(columns * n, items):
                     this_data[k].append(v.strip())
                 loops.append(this_data)
-            elif "".join(s).strip() != "":
-                warnings.warn(
-                    "Possible issue in cif file"
-                    " at line: {}".format("".join(s).strip())
-                )
+            elif ''.join(s).strip() != '':
+                warnings.warn('Possible issue in cif file' ' at line: {}'.format(''.join(s).strip()))
         return data, loops
 
 
@@ -277,10 +267,9 @@ class StarBase(StarProcess):
         core,
         entry_names: List[str] = None,
         exclude: list = None,
-        prefix: str = "_",
+        prefix: str = '_',
     ):
-
-        if not hasattr(core, "__len__"):
+        if not hasattr(core, '__len__'):
             core = [core]
         self.data = core
         if exclude is None:
@@ -289,11 +278,7 @@ class StarBase(StarProcess):
 
         if self.data:
             if entry_names is None:
-                entry_names = [
-                    self.data[0]._kwargs[key].name
-                    for key in self.data[0]._kwargs.keys()
-                    if key not in exclude
-                ]
+                entry_names = [self.data[0]._kwargs[key].name for key in self.data[0]._kwargs.keys() if key not in exclude]
         else:
             entry_names = []
 
@@ -307,31 +292,28 @@ class StarCollection(StarProcess):
         self.data = star_objects
 
     def __str__(self) -> str:
-        return "\n\n".join([str(data) for data in self.data])
+        return '\n\n'.join([str(data) for data in self.data])
 
     @classmethod
-    def from_string(cls, in_string, prefix="_"):
+    def from_string(cls, in_string, prefix='_'):
+        in_string = '\n'.join([item for item in in_string.split('\n') if item and item[0] != '#'])
 
-        in_string = "\n".join(
-            [item for item in in_string.split("\n") if item and item[0] != "#"]
-        )
-
-        blocks = in_string.split("data_")
+        blocks = in_string.split('data_')
         data_blocks = []
         for block in blocks:
             if not block:
                 continue
-            data_block = {"header": None, "loops": [], "data": {}}
-            items = block.split("\n")
+            data_block = {'header': None, 'loops': [], 'data': {}}
+            items = block.split('\n')
             if len(items) == 0:
                 continue
-            data_block["header"] = StarHeader.from_string("data_" + items[0])
-            data, loops = cls._loadBlock("\n".join(items[1:]))
+            data_block['header'] = StarHeader.from_string('data_' + items[0])
+            data, loops = cls._loadBlock('\n'.join(items[1:]))
             for loop in loops:
-                data_block["loops"].append(StarLoop.from_data(loop, prefix=prefix))
+                data_block['loops'].append(StarLoop.from_data(loop, prefix=prefix))
             for key in data.keys():
-                entry = StarEntry.from_string("{}   {}".format(key, data[key]))
-                data_block["data"][entry.name] = entry
+                entry = StarEntry.from_string('{}   {}'.format(key, data[key]))
+                data_block['data'][entry.name] = entry
             data_blocks.append(data_block)
         if len(data_blocks) == 1:
             data_blocks = data_blocks[0]
@@ -339,7 +321,7 @@ class StarCollection(StarProcess):
 
     @classmethod
     def from_file(cls, filename: str):
-        with open(filename, "r") as reader:
+        with open(filename, 'r') as reader:
             in_string = reader.read()
         if not in_string:
             in_string = filename
@@ -351,25 +333,21 @@ class StarSection(StarBase):
         return self._section_to_string()
 
     def _section_to_string(self):
-        s = ""
+        s = ''
         keys = [key for key in self.data[0]._kwargs.keys() if key not in self.exclude]
         for idx, key in enumerate(keys):
-            s += f"{StarEntry(self.data[0]._kwargs[key], self.labels[idx], prefix=self.prefix)}\n"
+            s += f'{StarEntry(self.data[0]._kwargs[key], self.labels[idx], prefix=self.prefix)}\n'
         return s
 
     def to_class(self, cls, name_conversions=None, skip=[]):
-        if not hasattr(cls, "from_pars"):
+        if not hasattr(cls, 'from_pars'):
             raise AttributeError
         if name_conversions is None:
-            name_conversions = [
-                [k1, k2] for k1, k2 in zip(self.labels, self.data[0]._kwargs.keys())
-            ]
-        new_object = cls.from_pars(
-            **{k[0]: self.data[0]._kwargs[k[1]].raw_value for k in name_conversions}
-        )
+            name_conversions = [[k1, k2] for k1, k2 in zip(self.labels, self.data[0]._kwargs.keys())]
+        new_object = cls.from_pars(**{k[0]: self.data[0]._kwargs[k[1]].raw_value for k in name_conversions})
         for key in name_conversions:
             attr = getattr(new_object, key[0])
-            if hasattr(self.data[0]._kwargs[key[1]], "fixed"):
+            if hasattr(self.data[0]._kwargs[key[1]], 'fixed'):
                 if self.data[0]._kwargs[key[1]].fixed is not None:
                     attr.fixed = self.data[0]._kwargs[key[1]].fixed
                 if self.data[0]._kwargs[key[1]].error is not None:
@@ -377,8 +355,8 @@ class StarSection(StarBase):
         return new_object
 
     @classmethod
-    def from_string(cls, in_string: str, name_conversion: List[str] = None, prefix="_"):
-        items = in_string.split("\n")
+    def from_string(cls, in_string: str, name_conversion: List[str] = None, prefix='_'):
+        items = in_string.split('\n')
         data = [FakeCore()]
         names = []
         for idx, item in enumerate(items):
@@ -387,9 +365,7 @@ class StarSection(StarBase):
             this_name = None
             if name_conversion is not None:
                 this_name = name_conversion[idx]
-            conv_item = StarEntry.from_string(
-                item, name_conversion=this_name, prefix=prefix
-            )
+            conv_item = StarEntry.from_string(item, name_conversion=this_name, prefix=prefix)
             names.append(conv_item.name)
             data[0]._kwargs[conv_item.name] = conv_item.to_fake_item()
         return cls(data, entry_names=names, prefix=prefix)
@@ -399,7 +375,7 @@ class StarSection(StarBase):
         cls,
         star_entries: List[StarEntry],
         name_conversions: List[str] = None,
-        prefix="_",
+        prefix='_',
     ):
         data = [FakeCore()]
         names = []
@@ -412,10 +388,7 @@ class StarSection(StarBase):
 
     def to_StarEntries(self) -> List[StarEntry]:
         keys = [key for key in self.data[0]._kwargs.keys() if key not in self.exclude]
-        return [
-            StarEntry(self.data[0]._kwargs[key], self.labels[idx], prefix=self.prefix)
-            for idx, key in enumerate(keys)
-        ]
+        return [StarEntry(self.data[0]._kwargs[key], self.labels[idx], prefix=self.prefix) for idx, key in enumerate(keys)]
 
 
 class StarLoop(StarBase):
@@ -423,9 +396,9 @@ class StarLoop(StarBase):
         return self._loop_to_string()
 
     def _loop_to_string(self):
-        s = "loop_"
+        s = 'loop_'
         if len(self.data) == 0:
-            return ""
+            return ''
         keys = [key for key in self.data[0]._kwargs.keys() if key not in self.exclude]
         for idx, kw in enumerate(keys):
             label = kw
@@ -433,29 +406,29 @@ class StarLoop(StarBase):
                 label = self.data[0]._kwargs[kw].name
             if self.labels[idx] is not None:
                 label = self.labels[idx]
-            s += "\n {}".format(self.prefix) + label
+            s += '\n {}'.format(self.prefix) + label
         for item in self.data:
-            line = "\n"
+            line = '\n'
             for kw in keys:
                 val = str(ItemHolder(item._kwargs[kw]))
-                if val.count(" ") == 0 and val.count("'") > 0:
+                if val.count(' ') == 0 and val.count("'") > 0:
                     val = val.strip("'")
-                if val[0] == ";":
-                    s += line + "\n" + val
-                    line = "\n"
+                if val[0] == ';':
+                    s += line + '\n' + val
+                    line = '\n'
                 elif len(line) + len(val) + 2 < self.maxlen:
-                    line += "  " + val
+                    line += '  ' + val
                 else:
                     s += line
-                    line = "\n  " + val
+                    line = '\n  ' + val
             s += line
         return s
 
     @classmethod
-    def from_string(cls, in_string: str, name_conversion: List[str] = None, prefix="_"):
+    def from_string(cls, in_string: str, name_conversion: List[str] = None, prefix='_'):
         data, loops = cls._loadBlock(in_string, prefix=prefix)
         if len(loops) > 1:
-            raise ValueError(f"String has more than one loop: {len(loops)}")
+            raise ValueError(f'String has more than one loop: {len(loops)}')
         return cls.from_data(loops[0], name_conversion, prefix)
 
     @classmethod
@@ -463,7 +436,7 @@ class StarLoop(StarBase):
         cls,
         star_sections: List[StarSection],
         name_conversion: List[str] = None,
-        prefix="_",
+        prefix='_',
     ):
         this_data = [section.data[0] for section in star_sections]
         all_names = star_sections[0].labels
@@ -472,13 +445,10 @@ class StarLoop(StarBase):
         return cls(this_data, all_names, prefix=prefix)
 
     def to_StarSections(self) -> List[StarSection]:
-        return [
-            StarSection(section, self.labels, prefix=self.prefix)
-            for section in self.data
-        ]
+        return [StarSection(section, self.labels, prefix=self.prefix) for section in self.data]
 
     @classmethod
-    def from_data(cls, loop: dict, name_conversion: List[str] = None, prefix="_"):
+    def from_data(cls, loop: dict, name_conversion: List[str] = None, prefix='_'):
         all_names = []
         all_data = []
         keys = list(loop.keys())
@@ -486,14 +456,14 @@ class StarLoop(StarBase):
             fk = FakeCore()
             for idx, key in enumerate(keys):
                 this_name = key
-                if this_name[0] == "_":
+                if this_name[0] == '_':
                     this_name = this_name[1:]
                 if name_conversion is not None:
                     this_name = name_conversion[idx]
                 if idx2 == 0:
                     all_names.append(this_name)
                 conv_item = StarEntry.from_string(
-                    "{}{}   {}".format(prefix, this_name, loop[key][idx2]),
+                    '{}{}   {}'.format(prefix, this_name, loop[key][idx2]),
                     this_name,
                     prefix=prefix,
                 )
@@ -502,26 +472,17 @@ class StarLoop(StarBase):
         return cls(all_data, all_names, prefix=prefix)
 
     def to_class(self, cls_outer, cls_inner, name_conversions=None):
-        if not hasattr(cls_inner, "from_pars"):
+        if not hasattr(cls_inner, 'from_pars'):
             raise AttributeError
         new_objects = []
         for idx in range(len(self.data)):
             if name_conversions is None:
-                keys = [
-                    key
-                    for key in self.data[idx]._kwargs.keys()
-                    if key not in self.exclude
-                ]
+                keys = [key for key in self.data[idx]._kwargs.keys() if key not in self.exclude]
                 name_conversions = [[k, k] for k in keys]
-            new_object = cls_inner.from_pars(
-                **{
-                    k[0]: self.data[idx]._kwargs[k[1]].raw_value
-                    for k in name_conversions
-                }
-            )
+            new_object = cls_inner.from_pars(**{k[0]: self.data[idx]._kwargs[k[1]].raw_value for k in name_conversions})
             for key in name_conversions:
                 attr = getattr(new_object, key[0])
-                if hasattr(self.data[idx]._kwargs[key[1]], "fixed"):
+                if hasattr(self.data[idx]._kwargs[key[1]], 'fixed'):
                     if self.data[idx]._kwargs[key[1]].fixed is not None:
                         attr.fixed = self.data[idx]._kwargs[key[1]].fixed
                     if self.data[idx]._kwargs[key[1]].error is not None:
@@ -529,24 +490,18 @@ class StarLoop(StarBase):
             new_objects.append(new_object)
         return cls_outer(cls_outer.__name__, *new_objects)
 
-    def join(self, otherLoop: "StarLoop", key: str) -> "StarLoop":
+    def join(self, otherLoop: 'StarLoop', key: str) -> 'StarLoop':
         if key not in self.labels or key not in otherLoop.labels:
-            raise AttributeError("Key must be common in both StarLoops")
+            raise AttributeError('Key must be common in both StarLoops')
         if len(self.data) != len(otherLoop.data):
-            raise AttributeError(
-                "There must be the same number of entries in both StarLoops"
-            )
+            raise AttributeError('There must be the same number of entries in both StarLoops')
         joint = StarLoop.from_string(str(self))
         for dataset in otherLoop.data:
-            lookup_value = dataset._kwargs["label"].raw_value
+            lookup_value = dataset._kwargs['label'].raw_value
             try:
-                lookup_idx = [d._kwargs["label"].raw_value for d in self.data].index(
-                    lookup_value
-                )
+                lookup_idx = [d._kwargs['label'].raw_value for d in self.data].index(lookup_value)
             except ValueError:
-                raise AttributeError(
-                    "Both StarLoops must contain the joining same keys"
-                )
+                raise AttributeError('Both StarLoops must contain the joining same keys')
             joint.data[lookup_idx]._kwargs.update(dataset._kwargs)
         joint.labels.extend([k for k in otherLoop.labels if k != key])
         return joint
@@ -557,9 +512,9 @@ class StarHeader:
         self.name = name
 
     def __str__(self) -> str:
-        return "data_" + self.name
+        return 'data_' + self.name
 
     @classmethod
     def from_string(cls, in_string: str):
-        name = in_string.split("data_")[1]
+        name = in_string.split('data_')[1]
         return cls(name)

--- a/easyCore/Utils/io/template.py
+++ b/easyCore/Utils/io/template.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.0.1"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.0.1'
 
 import datetime
 import json
@@ -24,7 +24,7 @@ from typing import Tuple
 from typing import Type
 from typing import TypeVar
 
-from easyCore import np
+import numpy as np
 
 if TYPE_CHECKING:
     from easyCore.Utils.typing import BV
@@ -89,24 +89,24 @@ class BaseEncoderDecoder:
 
         if isinstance(obj, datetime.datetime):
             return {
-                "@module": "datetime",
-                "@class": "datetime",
-                "string": obj.__str__(),
+                '@module': 'datetime',
+                '@class': 'datetime',
+                'string': obj.__str__(),
             }
         if np is not None:
             if isinstance(obj, np.ndarray):
-                if str(obj.dtype).startswith("complex"):
+                if str(obj.dtype).startswith('complex'):
                     return {
-                        "@module": "numpy",
-                        "@class": "array",
-                        "dtype": obj.dtype.__str__(),
-                        "data": [obj.real.tolist(), obj.imag.tolist()],
+                        '@module': 'numpy',
+                        '@class': 'array',
+                        'dtype': obj.dtype.__str__(),
+                        'data': [obj.real.tolist(), obj.imag.tolist()],
                     }
                 return {
-                    "@module": "numpy",
-                    "@class": "array",
-                    "dtype": obj.dtype.__str__(),
-                    "data": obj.tolist(),
+                    '@module': 'numpy',
+                    '@class': 'array',
+                    'dtype': obj.dtype.__str__(),
+                    'data': obj.tolist(),
                 }
             if isinstance(obj, np.generic):
                 return obj.item()
@@ -133,20 +133,20 @@ class BaseEncoderDecoder:
             if new_obj is not obj:
                 return new_obj
 
-        d = {"@module": get_class_module(obj), "@class": obj.__class__.__name__}
+        d = {'@module': get_class_module(obj), '@class': obj.__class__.__name__}
 
         try:
-            parent_module = get_class_module(obj).split(".")[0]
+            parent_module = get_class_module(obj).split('.')[0]
             module_version = import_module(parent_module).__version__  # type: ignore
-            d["@version"] = "{}".format(module_version)
+            d['@version'] = '{}'.format(module_version)
         except (AttributeError, ImportError):
-            d["@version"] = None  # type: ignore
+            d['@version'] = None  # type: ignore
 
         spec, args = BaseEncoderDecoder.get_arg_spec(obj.__class__.__init__)
-        if hasattr(obj, "_arg_spec"):
+        if hasattr(obj, '_arg_spec'):
             args = obj._arg_spec
 
-        redirect = getattr(obj, "_REDIRECT", {})
+        redirect = getattr(obj, '_REDIRECT', {})
 
         def runner(o):
             if full_encode:
@@ -165,20 +165,20 @@ class BaseEncoderDecoder:
                         a = runner(obj.__getattribute__(c))
                     except AttributeError:
                         try:
-                            a = runner(obj.__getattribute__("_" + c))
+                            a = runner(obj.__getattribute__('_' + c))
                         except AttributeError:
                             err = True
-                            if hasattr(obj, "kwargs"):
+                            if hasattr(obj, 'kwargs'):
                                 # type: ignore
-                                option = getattr(obj, "kwargs")
+                                option = getattr(obj, 'kwargs')
                                 if hasattr(option, c):
                                     v = getattr(option, c)
                                     delattr(option, c)
                                     d.update(runner(v))  # pylint: disable=E1101
                                     err = False
-                            if hasattr(obj, "_kwargs"):
+                            if hasattr(obj, '_kwargs'):
                                 # type: ignore
-                                option = getattr(obj, "_kwargs")
+                                option = getattr(obj, '_kwargs')
                                 if hasattr(option, c):
                                     v = getattr(option, c)
                                     delattr(option, c)
@@ -186,26 +186,24 @@ class BaseEncoderDecoder:
                                     err = False
                             if err:
                                 raise NotImplementedError(
-                                    "Unable to automatically determine as_dict "
-                                    "format from class. MSONAble requires all "
-                                    "args to be present as either self.argname or "
-                                    "self._argname, and kwargs to be present under"
-                                    "a self.kwargs variable to automatically "
-                                    "determine the dict format. Alternatively, "
-                                    "you can implement both as_dict and from_dict."
+                                    'Unable to automatically determine as_dict '
+                                    'format from class. MSONAble requires all '
+                                    'args to be present as either self.argname or '
+                                    'self._argname, and kwargs to be present under'
+                                    'a self.kwargs variable to automatically '
+                                    'determine the dict format. Alternatively, '
+                                    'you can implement both as_dict and from_dict.'
                                 )
-                d[c] = recursive_encoder(
-                    a, skip=skip, encoder=self, full_encode=full_encode, **kwargs
-                )
+                d[c] = recursive_encoder(a, skip=skip, encoder=self, full_encode=full_encode, **kwargs)
         if spec.varargs is not None and getattr(obj, spec.varargs, None) is not None:
             d.update({spec.varargs: getattr(obj, spec.varargs)})
-        if hasattr(obj, "_kwargs"):
+        if hasattr(obj, '_kwargs'):
             if not issubclass(type(obj), MutableSequence):
                 d_k = list(d.keys())
-                for k, v in getattr(obj, "_kwargs").items():
+                for k, v in getattr(obj, '_kwargs').items():
                     # We should have already obtained `key` and `_key`
                     if k not in skip and k not in d_k:
-                        if k[0] == "_" and k[1:] in d_k:
+                        if k[0] == '_' and k[1:] in d_k:
                             continue
                         vv = v
                         if k in redirect.keys():
@@ -221,11 +219,11 @@ class BaseEncoderDecoder:
                             **kwargs,
                         )
         if isinstance(obj, Enum):
-            d.update({"value": runner(obj.value)})  # pylint: disable=E1101
-        if hasattr(obj, "_convert_to_dict"):
+            d.update({'value': runner(obj.value)})  # pylint: disable=E1101
+        if hasattr(obj, '_convert_to_dict'):
             d = obj._convert_to_dict(d, self, skip=skip, **kwargs)
-        if hasattr(obj, "_borg") and "@id" not in d:
-            d["@id"] = str(obj._borg.map.convert_id(obj).int)
+        if hasattr(obj, '_borg') and '@id' not in d:
+            d['@id'] = str(obj._borg.map.convert_id(obj).int)
         return d
 
     @staticmethod
@@ -239,42 +237,32 @@ class BaseEncoderDecoder:
         """
         T_ = type(d)
         if isinstance(d, dict):
-            if "@module" in d and "@class" in d:
-                modname = d["@module"]
-                classname = d["@class"]
+            if '@module' in d and '@class' in d:
+                modname = d['@module']
+                classname = d['@class']
                 # if classname in DictSerializer.REDIRECT.get(modname, {}):
                 #     modname = DictSerializer.REDIRECT[modname][classname]["@module"]
                 #     classname = DictSerializer.REDIRECT[modname][classname]["@class"]
             else:
                 modname = None
                 classname = None
-            if modname and modname not in ["bson.objectid", "numpy"]:
-                if modname == "datetime" and classname == "datetime":
+            if modname and modname not in ['bson.objectid', 'numpy']:
+                if modname == 'datetime' and classname == 'datetime':
                     try:
-                        dt = datetime.datetime.strptime(
-                            d["string"], "%Y-%m-%d %H:%M:%S.%f"
-                        )
+                        dt = datetime.datetime.strptime(d['string'], '%Y-%m-%d %H:%M:%S.%f')
                     except ValueError:
-                        dt = datetime.datetime.strptime(
-                            d["string"], "%Y-%m-%d %H:%M:%S"
-                        )
+                        dt = datetime.datetime.strptime(d['string'], '%Y-%m-%d %H:%M:%S')
                     return dt
 
                 mod = __import__(modname, globals(), locals(), [classname], 0)
                 if hasattr(mod, classname):
                     cls_ = getattr(mod, classname)
-                    data = {
-                        k: BaseEncoderDecoder._convert_from_dict(v)
-                        for k, v in d.items()
-                        if not k.startswith("@")
-                    }
+                    data = {k: BaseEncoderDecoder._convert_from_dict(v) for k, v in d.items() if not k.startswith('@')}
                     return cls_(**data)
-            elif np is not None and modname == "numpy" and classname == "array":
-                if d["dtype"].startswith("complex"):
-                    return np.array(
-                        [r + i * 1j for r, i in zip(*d["data"])], dtype=d["dtype"]
-                    )
-                return np.array(d["data"], dtype=d["dtype"])
+            elif np is not None and modname == 'numpy' and classname == 'array':
+                if d['dtype'].startswith('complex'):
+                    return np.array([r + i * 1j for r, i in zip(*d['data'])], dtype=d['dtype'])
+                return np.array(d['data'], dtype=d['dtype'])
 
         if issubclass(T_, (list, MutableSequence)):
             return [BaseEncoderDecoder._convert_from_dict(x) for x in d]
@@ -282,13 +270,11 @@ class BaseEncoderDecoder:
 
 
 if TYPE_CHECKING:
-    _ = TypeVar("EC", bound=BaseEncoderDecoder)
+    _ = TypeVar('EC', bound=BaseEncoderDecoder)
     EC = Type[_]
 
 
-def recursive_encoder(
-    obj, skip: List[str] = [], encoder=None, full_encode=False, **kwargs
-):
+def recursive_encoder(obj, skip: List[str] = [], encoder=None, full_encode=False, **kwargs):
     """
     Walk through an object encoding it
     """
@@ -297,23 +283,13 @@ def recursive_encoder(
     T_ = type(obj)
     if issubclass(T_, (list, tuple, MutableSequence)):
         # Is it a core MutableSequence?
-        if (
-            hasattr(obj, "encode") and obj.__class__.__module__ != "builtins"
-        ):  # strings have encode
+        if hasattr(obj, 'encode') and obj.__class__.__module__ != 'builtins':  # strings have encode
             return encoder._convert_to_dict(obj, skip, full_encode, **kwargs)
         else:
-            return [
-                recursive_encoder(it, skip, encoder, full_encode, **kwargs)
-                for it in obj
-            ]
+            return [recursive_encoder(it, skip, encoder, full_encode, **kwargs) for it in obj]
     if isinstance(obj, dict):
-        return {
-            kk: recursive_encoder(vv, skip, encoder, full_encode, **kwargs)
-            for kk, vv in obj.items()
-        }
-    if (
-        hasattr(obj, "encode") and obj.__class__.__module__ != "builtins"
-    ):  # strings have encode
+        return {kk: recursive_encoder(vv, skip, encoder, full_encode, **kwargs) for kk, vv in obj.items()}
+    if hasattr(obj, 'encode') and obj.__class__.__module__ != 'builtins':  # strings have encode
         return encoder._convert_to_dict(obj, skip, full_encode, **kwargs)
     return obj
 
@@ -322,5 +298,5 @@ def get_class_module(obj):
     """
     Returns the REAL module of the class of the object.
     """
-    c = getattr(obj, "__old_class__", obj.__class__)
+    c = getattr(obj, '__old_class__', obj.__class__)
     return c.__module__

--- a/easyCore/Utils/io/template.py
+++ b/easyCore/Utils/io/template.py
@@ -9,23 +9,20 @@ __version__ = "0.0.1"
 
 import datetime
 import json
-
 from abc import abstractmethod
 from enum import Enum
 from importlib import import_module
 from inspect import getfullargspec
-from typing import (
-    List,
-    TYPE_CHECKING,
-    Callable,
-    Tuple,
-    Any,
-    Optional,
-    Dict,
-    MutableSequence,
-    TypeVar,
-    Type,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import MutableSequence
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
 
 from easyCore import np
 

--- a/easyCore/Utils/io/template.py
+++ b/easyCore/Utils/io/template.py
@@ -27,8 +27,7 @@ from typing import (
     Type,
 )
 
-from easyCore import np, _REDIRECT as GLOBAL_REDIRECT
-from easyCore import borg
+from easyCore import np
 
 if TYPE_CHECKING:
     from easyCore.Utils.typing import BV

--- a/easyCore/Utils/io/xml.py
+++ b/easyCore/Utils/io/xml.py
@@ -7,16 +7,19 @@ from __future__ import annotations
 __author__ = "github.com/wardsimon"
 __version__ = "0.0.1"
 
-import xml.etree.ElementTree as ET
-
-from numbers import Number
 import sys
-from typing import List, TYPE_CHECKING, Any, Optional
+import xml.etree.ElementTree as ET
+from numbers import Number
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import List
+from typing import Optional
 
 import numpy as np
 
+from easyCore.Utils.io.dict import DataDictSerializer
+from easyCore.Utils.io.dict import DictSerializer
 from easyCore.Utils.io.template import BaseEncoderDecoder
-from easyCore.Utils.io.dict import DictSerializer, DataDictSerializer
 
 if TYPE_CHECKING:
     from easyCore.Utils.typing import BV

--- a/easyCore/Utils/string.py
+++ b/easyCore/Utils/string.py
@@ -1,20 +1,19 @@
-__author__ = "github.com/wardsimon"
-__version__ = "0.1.0"
-
-
 #  SPDX-FileCopyrightText: 2023 easyCore contributors  <core@easyscience.software>
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
+
+from fractions import Fraction
+
+__author__ = 'github.com/wardsimon'
+__version__ = '0.1.0'
+
+
 """
 This module provides utility classes for string operations.
 """
-# import re
-from fractions import Fraction
 
 
-def transformation_to_string(
-    matrix, translation_vec=(0, 0, 0), components=("x", "y", "z"), c="", delim=","
-):
+def transformation_to_string(matrix, translation_vec=(0, 0, 0), components=('x', 'y', 'z'), c='', delim=','):
     """
     Convenience method. Given matrix returns string, e.g. x+2y+1/4
     :param matrix
@@ -26,26 +25,24 @@ def transformation_to_string(
     """
     parts = []
     for i in range(3):
-        s = ""
+        s = ''
         m = matrix[i]
         t = translation_vec[i]
         for j, dim in enumerate(components):
             if m[j] != 0:
                 f = Fraction(m[j]).limit_denominator()
-                if s != "" and f >= 0:
-                    s += "+"
+                if s != '' and f >= 0:
+                    s += '+'
                 if abs(f.numerator) != 1:
                     s += str(f.numerator)
                 elif f < 0:
-                    s += "-"
+                    s += '-'
                 s += c + dim
                 if f.denominator != 1:
-                    s += "/" + str(f.denominator)
+                    s += '/' + str(f.denominator)
         if t != 0:
-            s += ("+" if (t > 0 and s != "") else "") + str(
-                Fraction(t).limit_denominator()
-            )
-        if s == "":
-            s += "0"
+            s += ('+' if (t > 0 and s != '') else '') + str(Fraction(t).limit_denominator())
+        if s == '':
+            s += '0'
         parts.append(s)
     return delim.join(parts)

--- a/easyCore/Utils/typing.py
+++ b/easyCore/Utils/typing.py
@@ -6,13 +6,9 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 # Template interface
-from easyCore.Objects.Inferface import iF
 
 # Template Constraint
-from easyCore.Fitting.Constraints import C
 
 # Variable such as Descriptor, Parameter
-from easyCore.Objects.Variable import V
 
 # Base object from BaseObj (B) a BaseObject OR Variable (BV)
-from easyCore.Objects.ObjectClasses import B, BV

--- a/easyCore/__init__.py
+++ b/easyCore/__init__.py
@@ -6,8 +6,9 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.3.1"
 
 
-from easyCore.Objects.Borg import Borg
 import pint
+
+from easyCore.Objects.Borg import Borg
 
 default_fitting_engine = "lmfit"
 

--- a/easyCore/__init__.py
+++ b/easyCore/__init__.py
@@ -5,11 +5,9 @@
 __author__ = "github.com/wardsimon"
 __version__ = "0.3.1"
 
-import numpy as np
 
 from easyCore.Objects.Borg import Borg
 import pint
-from .REDIRECT import _REDIRECT
 
 default_fitting_engine = "lmfit"
 

--- a/easyCore/__init__.py
+++ b/easyCore/__init__.py
@@ -2,15 +2,16 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.3.1"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.3.1'
 
 
+import numpy as np  # noqa: F401  This is used in the other codebases that uses easyCore
 import pint
 
 from easyCore.Objects.Borg import Borg
 
-default_fitting_engine = "lmfit"
+default_fitting_engine = 'lmfit'
 
 ureg = pint.UnitRegistry()
 borg = Borg()

--- a/easyCore/models/polynomial.py
+++ b/easyCore/models/polynomial.py
@@ -7,12 +7,15 @@ __version__ = "0.0.1"
 
 
 import functools
+from typing import ClassVar
+from typing import Iterable
+from typing import Optional
+from typing import Union
 
 from easyCore import np
-from easyCore.Objects.ObjectClasses import BaseObj, Parameter
 from easyCore.Objects.Groups import BaseCollection
-
-from typing import ClassVar, Optional, Iterable, Union
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 
 def designate_calc_fn(func):

--- a/easyCore/models/polynomial.py
+++ b/easyCore/models/polynomial.py
@@ -2,8 +2,8 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
-__author__ = "github.com/wardsimon"
-__version__ = "0.0.1"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.0.1'
 
 
 import functools
@@ -12,7 +12,8 @@ from typing import Iterable
 from typing import Optional
 from typing import Union
 
-from easyCore import np
+import numpy as np
+
 from easyCore.Objects.Groups import BaseCollection
 from easyCore.Objects.ObjectClasses import BaseObj
 from easyCore.Objects.ObjectClasses import Parameter
@@ -22,7 +23,7 @@ def designate_calc_fn(func):
     @functools.wraps(func)
     def wrapper(obj, *args, **kwargs):
         for name in list(obj.__annotations__.keys()):
-            func.__globals__["_" + name] = getattr(obj, name).raw_value
+            func.__globals__['_' + name] = getattr(obj, name).raw_value
         return func(obj, *args, **kwargs)
 
     return wrapper
@@ -44,14 +45,10 @@ class Polynomial(BaseObj):
 
     def __init__(
         self,
-        name: str = "polynomial",
-        coefficients: Optional[
-            Union[Iterable[Union[float, Parameter]], BaseCollection]
-        ] = None,
+        name: str = 'polynomial',
+        coefficients: Optional[Union[Iterable[Union[float, Parameter]], BaseCollection]] = None,
     ):
-        super(Polynomial, self).__init__(
-            name, coefficients=BaseCollection("coefficients")
-        )
+        super(Polynomial, self).__init__(name, coefficients=BaseCollection('coefficients'))
         if coefficients is not None:
             if issubclass(type(coefficients), BaseCollection):
                 self.coefficients = coefficients
@@ -60,13 +57,11 @@ class Polynomial(BaseObj):
                     if issubclass(type(item), Parameter):
                         self.coefficients.append(item)
                     elif isinstance(item, float):
-                        self.coefficients.append(
-                            Parameter(name="c{}".format(index), value=item)
-                        )
+                        self.coefficients.append(Parameter(name='c{}'.format(index), value=item))
                     else:
-                        raise TypeError("Coefficients must be floats or Parameters")
+                        raise TypeError('Coefficients must be floats or Parameters')
             else:
-                raise TypeError("coefficients must be a list or a BaseCollection")
+                raise TypeError('coefficients must be a list or a BaseCollection')
 
     def __call__(self, x: np.ndarray, *args, **kwargs) -> np.ndarray:
         return np.polyval([c.raw_value for c in self.coefficients], x)
@@ -74,22 +69,17 @@ class Polynomial(BaseObj):
     def __repr__(self):
         s = []
         if len(self.coefficients) >= 1:
-            s += [f"{self.coefficients[0].raw_value}"]
+            s += [f'{self.coefficients[0].raw_value}']
             if len(self.coefficients) >= 2:
-                s += [f"{self.coefficients[1].raw_value}x"]
+                s += [f'{self.coefficients[1].raw_value}x']
                 if len(self.coefficients) >= 3:
-                    s += [
-                        f"{c.raw_value}x^{i+2}"
-                        for i, c in enumerate(self.coefficients[2:])
-                        if c.raw_value != 0
-                    ]
+                    s += [f'{c.raw_value}x^{i+2}' for i, c in enumerate(self.coefficients[2:]) if c.raw_value != 0]
         s.reverse()
-        s = " + ".join(s)
-        return "Polynomial({}, {})".format(self.name, s)
+        s = ' + '.join(s)
+        return 'Polynomial({}, {})'.format(self.name, s)
 
 
 class Line(BaseObj):
-
     m: ClassVar[Parameter]
     c: ClassVar[Parameter]
 
@@ -98,7 +88,7 @@ class Line(BaseObj):
         m: Optional[Union[Parameter, float]] = None,
         c: Optional[Union[Parameter, float]] = None,
     ):
-        super(Line, self).__init__("line", m=Parameter("m", 1.0), c=Parameter("c", 0.0))
+        super(Line, self).__init__('line', m=Parameter('m', 1.0), c=Parameter('c', 0.0))
         if m is not None:
             self.m = m
         if c is not None:
@@ -109,4 +99,4 @@ class Line(BaseObj):
         return self.m.raw_value * x + self.c.raw_value
 
     def __repr__(self):
-        return "{}({}, {})".format(self.__class__.__name__, self.m, self.c)
+        return '{}({}, {})'.format(self.__class__.__name__, self.m, self.c)

--- a/examples_old/dimer_example.ipynb
+++ b/examples_old/dimer_example.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from easyCore import np\n",
+    "import numpy as np\n",
     "from easyCore.Datasets.xarray import xr\n",
     "from easyCore.Objects.Base import Parameter, BaseObj\n",
     "from easyCore.Fitting.Fitting import Fitter"

--- a/examples_old/example1.py
+++ b/examples_old/example1.py
@@ -2,8 +2,10 @@ __author__ = 'github.com/wardsimon'
 __version__ = '0.1.0'
 
 import numpy as np
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
+
 from easyCore.Fitting.Fitting import Fitter
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 # This is a simple example of creating an object which has fitable parameters
 

--- a/examples_old/example1_dream.py
+++ b/examples_old/example1_dream.py
@@ -2,8 +2,10 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 import numpy as np
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
+
 from easyCore.Fitting.Fitting import Fitter
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 # This is a simple example of creating an object which has fitable parameters
 

--- a/examples_old/example2.py
+++ b/examples_old/example2.py
@@ -2,8 +2,10 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 import numpy as np
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
+
 from easyCore.Fitting.Fitting import Fitter
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 # In this case we have inherited from `BaseObj` to create a class which has fitable attributes.
 

--- a/examples_old/example3.py
+++ b/examples_old/example3.py
@@ -4,8 +4,10 @@ __version__ = '0.1.0'
 from typing import Callable
 
 import numpy as np
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
+
 from easyCore.Fitting.Fitting import Fitter
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 # In this case we have inherited from `BaseObj` to create a class which has fitable attributes.
 # This class does not know about the `Calculator`, only the interface.

--- a/examples_old/example4.py
+++ b/examples_old/example4.py
@@ -2,16 +2,18 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 import json
-from typing import Callable, List
-from easyCore.Objects.core import ComponentSerializer
+from abc import ABCMeta
+from abc import abstractmethod
+from typing import Callable
+from typing import List
 
 import numpy as np
 
 from easyCore import borg
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
 from easyCore.Fitting.Fitting import Fitter
-
-from abc import ABCMeta, abstractmethod
+from easyCore.Objects.core import ComponentSerializer
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 # This is a much more complex case where we have calculators, interfaces, interface factory and an
 # inherited object (from `BaseObj`). In this case the Line class is available with/without an interface

--- a/examples_old/example5_broken.py
+++ b/examples_old/example5_broken.py
@@ -2,20 +2,20 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 import json
+from abc import ABCMeta
+from abc import abstractmethod
 from typing import Callable
-from easyCore.Objects.core import ComponentSerializer
 
 import numpy as np
 
 from easyCore import borg
-from easyCore.Objects.Base import Parameter, BaseObj
+from easyCore.Fitting.Fitting import Fitter
+from easyCore.Objects.Base import BaseObj
+from easyCore.Objects.Base import Parameter
+from easyCore.Objects.core import ComponentSerializer
 
 # from easyCore.Objects.Base import LoggedProperty
 from easyCore.Objects.Inferface import InterfaceFactoryTemplate
-from easyCore.Fitting.Fitting import Fitter
-
-from abc import ABCMeta, abstractmethod
-
 
 # This is a much more complex case where we have calculators, interfaces, interface factory and an
 # inherited object (from `BaseObj`). In this case the Line class is available with/without an interface

--- a/examples_old/example6_broken.py
+++ b/examples_old/example6_broken.py
@@ -2,18 +2,18 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
 import json
+from abc import ABCMeta
+from abc import abstractmethod
 from typing import Callable
-from easyCore.Objects.core import ComponentSerializer
 
 import numpy as np
 
 from easyCore import borg
-from easyCore.Objects.Base import Parameter, BaseObj
-from easyCore.Objects.Inferface import InterfaceFactoryTemplate
 from easyCore.Fitting.Fitting import Fitter
-
-from abc import ABCMeta, abstractmethod
-
+from easyCore.Objects.Base import BaseObj
+from easyCore.Objects.Base import Parameter
+from easyCore.Objects.core import ComponentSerializer
+from easyCore.Objects.Inferface import InterfaceFactoryTemplate
 
 # This is a much more complex case where we have calculators, interfaces, interface factory and an
 # inherited object (from `BaseObj`). In this case the Line class is available with/without an interface

--- a/examples_old/example_dataset.py
+++ b/examples_old/example_dataset.py
@@ -1,10 +1,12 @@
 __author__ = 'github.com/wardsimon'
 __version__ = '0.1.0'
 
+import time
+
+import matplotlib.pyplot as plt
+
 from easyCore import np
 from easyCore.Datasets.xarray import xr
-import time
-import matplotlib.pyplot as plt
 
 d = xr.Dataset()
 

--- a/examples_old/example_dataset.py
+++ b/examples_old/example_dataset.py
@@ -5,7 +5,7 @@ import time
 
 import matplotlib.pyplot as plt
 
-from easyCore import np
+import numpy as np
 from easyCore.Datasets.xarray import xr
 
 d = xr.Dataset()

--- a/examples_old/example_dataset2.py
+++ b/examples_old/example_dataset2.py
@@ -1,11 +1,13 @@
 __author__ = "github.com/wardsimon"
 __version__ = "0.1.0"
 
+import matplotlib.pyplot as plt
+
 from easyCore import np
 from easyCore.Datasets.xarray import xr
-import matplotlib.pyplot as plt
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
 from easyCore.Fitting.Fitting import Fitter
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 d = xr.Dataset()
 

--- a/examples_old/example_dataset2.py
+++ b/examples_old/example_dataset2.py
@@ -3,7 +3,7 @@ __version__ = "0.1.0"
 
 import matplotlib.pyplot as plt
 
-from easyCore import np
+import numpy as np
 from easyCore.Datasets.xarray import xr
 from easyCore.Fitting.Fitting import Fitter
 from easyCore.Objects.ObjectClasses import BaseObj

--- a/examples_old/example_dataset2pt2.py
+++ b/examples_old/example_dataset2pt2.py
@@ -3,7 +3,7 @@ __version__ = '0.1.0'
 
 import matplotlib.pyplot as plt
 
-from easyCore import np
+import numpy as np
 from easyCore.Datasets.xarray import xr
 from easyCore.Fitting.Fitting import Fitter
 from easyCore.Objects.ObjectClasses import BaseObj

--- a/examples_old/example_dataset2pt2.py
+++ b/examples_old/example_dataset2pt2.py
@@ -1,11 +1,13 @@
 __author__ = 'github.com/wardsimon'
 __version__ = '0.1.0'
 
+import matplotlib.pyplot as plt
+
 from easyCore import np
 from easyCore.Datasets.xarray import xr
-import matplotlib.pyplot as plt
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
 from easyCore.Fitting.Fitting import Fitter
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 d = xr.Dataset()
 

--- a/examples_old/example_dataset2pt2_broken.py
+++ b/examples_old/example_dataset2pt2_broken.py
@@ -3,7 +3,7 @@ __version__ = '0.1.0'
 
 import matplotlib.pyplot as plt
 
-from easyCore import np
+import numpy as np
 from easyCore.Datasets.xarray import xr
 from easyCore.Fitting.Fitting import Fitter
 from easyCore.Objects.Base import BaseObj

--- a/examples_old/example_dataset2pt2_broken.py
+++ b/examples_old/example_dataset2pt2_broken.py
@@ -1,11 +1,13 @@
 __author__ = 'github.com/wardsimon'
 __version__ = '0.1.0'
 
+import matplotlib.pyplot as plt
+
 from easyCore import np
 from easyCore.Datasets.xarray import xr
-import matplotlib.pyplot as plt
-from easyCore.Objects.Base import Parameter, BaseObj
 from easyCore.Fitting.Fitting import Fitter
+from easyCore.Objects.Base import BaseObj
+from easyCore.Objects.Base import Parameter
 
 d = xr.Dataset()
 

--- a/examples_old/example_dataset3.py
+++ b/examples_old/example_dataset3.py
@@ -1,14 +1,16 @@
 __author__ = 'github.com/wardsimon'
 __version__ = '0.1.0'
 
-from easyCore import np
-
-from easyCore.Datasets.xarray import xr
 import time
+
 import matplotlib.pyplot as plt
 
+from easyCore import np
+from easyCore.Datasets.xarray import xr
 from easyCore.Fitting.Fitting import Fitter
-from easyCore.Objects.ObjectClasses import BaseObj, Parameter
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
+
 d = xr.Dataset()
 
 nx = 5E2

--- a/examples_old/example_dataset3.py
+++ b/examples_old/example_dataset3.py
@@ -5,7 +5,7 @@ import time
 
 import matplotlib.pyplot as plt
 
-from easyCore import np
+import numpy as np
 from easyCore.Datasets.xarray import xr
 from easyCore.Fitting.Fitting import Fitter
 from easyCore.Objects.ObjectClasses import BaseObj

--- a/examples_old/example_dataset3pt2.py
+++ b/examples_old/example_dataset3pt2.py
@@ -3,7 +3,7 @@ __version__ = '0.1.0'
 
 import matplotlib.pyplot as plt
 
-from easyCore import np
+import numpy as np
 from easyCore.Datasets.xarray import xr
 from easyCore.Fitting.Fitting import Fitter
 from easyCore.Objects.ObjectClasses import BaseObj

--- a/examples_old/example_dataset3pt2.py
+++ b/examples_old/example_dataset3pt2.py
@@ -1,13 +1,14 @@
 __author__ = 'github.com/wardsimon'
 __version__ = '0.1.0'
 
-from easyCore import np
-
-from easyCore.Datasets.xarray import xr
 import matplotlib.pyplot as plt
 
+from easyCore import np
+from easyCore.Datasets.xarray import xr
 from easyCore.Fitting.Fitting import Fitter
-from easyCore.Objects.ObjectClasses import BaseObj, Parameter
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
+
 d = xr.Dataset()
 
 nx = 5E2

--- a/examples_old/example_dataset4.py
+++ b/examples_old/example_dataset4.py
@@ -3,7 +3,7 @@ __version__ = '0.1.0'
 
 import matplotlib.pyplot as plt
 
-from easyCore import np
+import numpy as np
 from easyCore.Datasets.xarray import xr
 from easyCore.Fitting.Fitting import Fitter
 from easyCore.Objects.ObjectClasses import BaseObj

--- a/examples_old/example_dataset4.py
+++ b/examples_old/example_dataset4.py
@@ -1,12 +1,13 @@
 __author__ = 'github.com/wardsimon'
 __version__ = '0.1.0'
 
+import matplotlib.pyplot as plt
+
 from easyCore import np
 from easyCore.Datasets.xarray import xr
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
 from easyCore.Fitting.Fitting import Fitter
-
-import matplotlib.pyplot as plt
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 d = xr.Dataset()
 

--- a/examples_old/example_dataset4_2.py
+++ b/examples_old/example_dataset4_2.py
@@ -3,7 +3,7 @@ __version__ = '0.1.0'
 
 import matplotlib.pyplot as plt
 
-from easyCore import np
+import numpy as np
 from easyCore.Datasets.xarray import xr
 from easyCore.Fitting.Fitting import Fitter
 from easyCore.Objects.ObjectClasses import BaseObj

--- a/examples_old/example_dataset4_2.py
+++ b/examples_old/example_dataset4_2.py
@@ -1,12 +1,13 @@
 __author__ = 'github.com/wardsimon'
 __version__ = '0.1.0'
 
+import matplotlib.pyplot as plt
+
 from easyCore import np
 from easyCore.Datasets.xarray import xr
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
 from easyCore.Fitting.Fitting import Fitter
-
-import matplotlib.pyplot as plt
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 d = xr.Dataset()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,26 +24,26 @@ classifiers = [
 ]
 requires-python = ">=3.9,<3.12"
 dependencies = [
+    "asteval",
+    "bumps",
+    "DFO-LS",
+    "lmfit",
     "numpy",
     "pint",
     "uncertainties",
-    "lmfit",
-    "bumps",
-    "asteval",
-    "DFO-LS",
     "xarray"
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "pytest-cov",
+    "build",
     "codecov",
     "flake8",
-    "tox-gh-actions",
-    "ruff",
     "matplotlib",
-    "build"
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "tox-gh-actions"
 ]
 docs = [
     "doc8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dev = [
     "pytest-cov",
     "codecov",
     "flake8",
-    "tox-gh-actions"
+    "tox-gh-actions",
+    "ruff"
 ]
 docs = [
     "doc8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,79 +1,80 @@
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling<=1.21.0"]  
+build-backend = "hatchling.build"
 
-[tool.poetry]
-name = "easyScienceCore"
-version = "0.3.1"
+[project]
+name = "easyCore"
+version = "0.3.1-dev"
 description = "Generic logic for easyScience libraries"
-license = "BSD-3-Clause"
-authors = ["Simon Ward"]
 readme = "README.md"
+authors = [
+    {name = "Simon Ward"},
+    {name = "Andreas Pedersen", email = "andreas.pedersen@ess.eu"}
+]
+maintainers = [
+    {name = "Andreas Pedersen", email = "andreas.pedersen@ess.eu"}
+]
+license = "BSD-3-Clause"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering",
+    "Development Status :: 3 - Alpha"
+]
+requires-python = ">=3.9,<3.12"
+dependencies = [
+    "numpy",
+    "pint",
+    "uncertainties",
+    "lmfit",
+    "bumps",
+    "asteval",
+    "DFO-LS",
+    "xarray"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "codecov",
+    "flake8",
+    "tox-gh-actions"
+]
+docs = [
+    "doc8",
+    "readme-renderer",
+    "Sphinx",
+    "sphinx-rtd-theme",
+    "sphinx-autodoc-typehints", 
+    "sphinx-gallery"
+]
+
+[project.urls]
 homepage = "https://github.com/easyScience/easyCore"
 documentation = "https://github.com/easyScience/easyCore"
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Developers",  # Define that your audience are developers
-    "Topic :: Scientific/Engineering :: Physics",
-    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",  # Again, pick a license
-    "Programming Language :: Python :: 3 :: Only",
-]
-packages = [ { include = "easyCore" } ]
 
-[tool.poetry.dependencies]
-python = ">=3.8"
-numpy = "^1.21"
-pint = ">=0.17,<0.19"
-uncertainties = "^3.1"
-lmfit = "^1.0"
-bumps = ">=0.8,<0.10"
-asteval = "^0.9.27"
-DFO-LS = {version = "^1.2", optional = true}
-xarray = ">=0.16,<2023.2"
-pytest = {version = "^7.0.0", optional = true}
-pytest-cov = {version = "^3.0.0", optional = true}
-codecov = {version = "^2.1.11", optional = true}
-flake8 = {version = "^5.0", optional = true}
-tox-gh-actions = {version = "^2.11", optional = true}
-doc8 = {version = "^0.11.0", optional = true}
-readme-renderer = {version = ">=35,<38", optional = true}
-Sphinx = {version = ">=4.0.2,<7.0.0", optional = true}
-sphinx-rtd-theme = {version = "^1.0.0", optional = true}
-sphinx-autodoc-typehints = {version = "^1.12.0", optional = true}
-sphinx-gallery = {version = ">=0.10,<0.12", optional = true}
+[tool.hatch.metadata]
+allow-direct-references = true
 
-[tool.poetry.extras]
-graphics = ['holoviews']
-full = ['DFO-LS', 'holoviews']
-test = ['DFO-LS', 'pytest', 'pytest-cov', 'codecov', 'flake8']
-docs = ['doc8', 'readme-renderer', 'Sphinx', 'sphinx-rtd-theme', 'sphinx-autodoc-typehints', 'sphinx-gallery']
-ci = ['DFO-LS', 'pytest', 'pytest-cov', 'codecov', 'flake8', 'tox-gh-actions']
+[tool.hatch.build.targets.wheel]
+packages = ["easyCore"]
+
+[tool.coverage.run]
+source = ['easyCore']
 
 [tool.github.info]
 organization = 'easyScience'
 repo = 'easyCore'
 
-[tool.coverage.run]
-source = ['easyCore']
-
-[tool.black]
-line-length = 88
-target-version = ['py38']
-include = '\.pyi?$'
-extend-exclude = '''
-# A regex preceded with ^/ will apply only to files and directories
-# in the root of the project.
-^/foo.py  # exclude a file named foo.py in the root of the project (in addition to the defaults)
-'''
-
 [tool.tox]
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = py{38,39,310,311}
+envlist = py{39,310,311}
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
@@ -94,8 +95,114 @@ passenv =
     GITHUB_SHA
     COVERAGE_FILE
 deps = coverage
-whitelist_externals = poetry
 commands =
-    pip install '.[ci]'
+    pip install -e '.[dev]'
     pytest --cov --cov-report=xml
 """
+
+
+
+
+
+
+
+#[tool.poetry]
+#name = "easyScienceCore"
+#version = "0.3.1-dev"
+#description = "Generic logic for easyScience libraries"
+#license = "BSD-3-Clause"
+#authors = ["Simon Ward"]
+#readme = "README.md"
+#homepage = "https://github.com/easyScience/easyCore"
+#documentation = "https://github.com/easyScience/easyCore"
+#classifiers = [
+#    "Development Status :: 3 - Alpha",
+#    "Intended Audience :: Developers",  # Define that your audience are developers
+#    "Topic :: Scientific/Engineering :: Physics",
+#    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",  # Again, pick a license
+#    "Programming Language :: Python :: 3 :: Only",
+#]
+#packages = [ { include = "easyCore" } ]
+
+#[tool.poetry.dependencies]
+#python = ">=3.8"
+#numpy = "^1.21"
+#pint = ">=0.17,<0.19"
+#uncertainties = "^3.1"
+#lmfit = "^1.0"
+#bumps = ">=0.8,<0.10"
+#asteval = "^0.9.27"
+#DFO-LS = {version = "^1.2", optional = true}
+#xarray = ">=0.16,<2023.2"
+#pytest = {version = "^7.0.0", optional = true}
+#pytest-cov = {version = "^3.0.0", optional = true}
+#codecov = {version = "^2.1.11", optional = true}
+#flake8 = {version = "^5.0", optional = true}
+#tox-gh-actions = {version = "^2.11", optional = true}
+#doc8 = {version = "^0.11.0", optional = true}
+#readme-renderer = {version = ">=35,<38", optional = true}
+#Sphinx = {version = ">=4.0.2,<7.0.0", optional = true}
+#sphinx-rtd-theme = {version = "^1.0.0", optional = true}
+#sphinx-autodoc-typehints = {version = "^1.12.0", optional = true}
+#sphinx-gallery = {version = ">=0.10,<0.12", optional = true}
+
+#[tool.poetry.extras]
+#graphics = ['holoviews']
+#full = ['DFO-LS', 'holoviews']
+#test = ['DFO-LS', 'pytest', 'pytest-cov', 'codecov', 'flake8']
+#docs = ['doc8', 'readme-renderer', 'Sphinx', 'sphinx-rtd-theme', 'sphinx-autodoc-typehints', 'sphinx-gallery']
+#ci = ['DFO-LS', 'pytest', 'pytest-cov', 'codecov', 'flake8', 'tox-gh-actions']
+
+
+
+
+#[tool.github.info]
+#organization = 'easyScience'
+#repo = 'easyCore'
+
+#[tool.coverage.run]
+#source = ['easyCore']
+
+#[tool.black]
+#line-length = 88
+#target-version = ['py38']
+#include = '\.pyi?$'
+#extend-exclude = '''
+## A regex preceded with ^/ will apply only to files and directories
+## in the root of the project.
+#^/foo.py  # exclude a file named foo.py in the root of the project (in addition to the defaults)
+#'''
+
+#[tool.tox]
+#legacy_tox_ini = """
+#[tox]
+#isolated_build = True
+#envlist = py{38,39,310,311}
+#[gh-actions]
+#python =
+#    3.8: py38
+#    3.9: py39
+#    3.10: py310
+#    3.11: py311
+#[gh-actions:env]
+#PLATFORM =
+#    ubuntu-latest: linux
+#    macos-latest: macos
+#    windows-latest: windows
+#[testenv]
+#passenv =
+#    CI
+#    GITHUB_ACTIONS
+#    GITHUB_ACTION
+#    GITHUB_REF
+#    GITHUB_REPOSITORY
+#    GITHUB_HEAD_REF
+#    GITHUB_RUN_ID
+#    GITHUB_SHA
+#    COVERAGE_FILE
+#deps = coverage
+#whitelist_externals = poetry
+#commands =
+#    pip install '.[ci]'
+#    pytest --cov --cov-report=xml
+#"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dev = [
     "flake8",
     "tox-gh-actions",
     "ruff",
-    "matplotlib"
+    "matplotlib",
+    "build"
 ]
 docs = [
     "doc8",
@@ -142,108 +143,3 @@ select = [
 
 [tool.ruff.lint.isort]
 force-single-line = true
-
-
-
-
-
-#[tool.poetry]
-#name = "easyScienceCore"
-#version = "0.3.1-dev"
-#description = "Generic logic for easyScience libraries"
-#license = "BSD-3-Clause"
-#authors = ["Simon Ward"]
-#readme = "README.md"
-#homepage = "https://github.com/easyScience/easyCore"
-#documentation = "https://github.com/easyScience/easyCore"
-#classifiers = [
-#    "Development Status :: 3 - Alpha",
-#    "Intended Audience :: Developers",  # Define that your audience are developers
-#    "Topic :: Scientific/Engineering :: Physics",
-#    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",  # Again, pick a license
-#    "Programming Language :: Python :: 3 :: Only",
-#]
-#packages = [ { include = "easyCore" } ]
-
-#[tool.poetry.dependencies]
-#python = ">=3.8"
-#numpy = "^1.21"
-#pint = ">=0.17,<0.19"
-#uncertainties = "^3.1"
-#lmfit = "^1.0"
-#bumps = ">=0.8,<0.10"
-#asteval = "^0.9.27"
-#DFO-LS = {version = "^1.2", optional = true}
-#xarray = ">=0.16,<2023.2"
-#pytest = {version = "^7.0.0", optional = true}
-#pytest-cov = {version = "^3.0.0", optional = true}
-#codecov = {version = "^2.1.11", optional = true}
-#flake8 = {version = "^5.0", optional = true}
-#tox-gh-actions = {version = "^2.11", optional = true}
-#doc8 = {version = "^0.11.0", optional = true}
-#readme-renderer = {version = ">=35,<38", optional = true}
-#Sphinx = {version = ">=4.0.2,<7.0.0", optional = true}
-#sphinx-rtd-theme = {version = "^1.0.0", optional = true}
-#sphinx-autodoc-typehints = {version = "^1.12.0", optional = true}
-#sphinx-gallery = {version = ">=0.10,<0.12", optional = true}
-
-#[tool.poetry.extras]
-#graphics = ['holoviews']
-#full = ['DFO-LS', 'holoviews']
-#test = ['DFO-LS', 'pytest', 'pytest-cov', 'codecov', 'flake8']
-#docs = ['doc8', 'readme-renderer', 'Sphinx', 'sphinx-rtd-theme', 'sphinx-autodoc-typehints', 'sphinx-gallery']
-#ci = ['DFO-LS', 'pytest', 'pytest-cov', 'codecov', 'flake8', 'tox-gh-actions']
-
-
-
-
-#[tool.github.info]
-#organization = 'easyScience'
-#repo = 'easyCore'
-
-#[tool.coverage.run]
-#source = ['easyCore']
-
-#[tool.black]
-#line-length = 88
-#target-version = ['py38']
-#include = '\.pyi?$'
-#extend-exclude = '''
-## A regex preceded with ^/ will apply only to files and directories
-## in the root of the project.
-#^/foo.py  # exclude a file named foo.py in the root of the project (in addition to the defaults)
-#'''
-
-#[tool.tox]
-#legacy_tox_ini = """
-#[tox]
-#isolated_build = True
-#envlist = py{38,39,310,311}
-#[gh-actions]
-#python =
-#    3.8: py38
-#    3.9: py39
-#    3.10: py310
-#    3.11: py311
-#[gh-actions:env]
-#PLATFORM =
-#    ubuntu-latest: linux
-#    macos-latest: macos
-#    windows-latest: windows
-#[testenv]
-#passenv =
-#    CI
-#    GITHUB_ACTIONS
-#    GITHUB_ACTION
-#    GITHUB_REF
-#    GITHUB_REPOSITORY
-#    GITHUB_HEAD_REF
-#    GITHUB_RUN_ID
-#    GITHUB_SHA
-#    COVERAGE_FILE
-#deps = coverage
-#whitelist_externals = poetry
-#commands =
-#    pip install '.[ci]'
-#    pytest --cov --cov-report=xml
-#"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,44 @@ commands =
     pytest --cov --cov-report=xml
 """
 
+[tool.ruff]
+line-length = 127
+exclude = [
+    "docs",
+]
 
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.ruff.per-file-ignores]
+# allow asserts in test files
+"*test_*.py" = ["S101"]
+
+[tool.ruff.lint]
+ignore-init-module-imports = true
+select = [
+    # flake8 settings from existing CI setup
+    "E9", "F63", "F7", "F82",
+    # Code should be polished to fulfill all cases bellow
+    # https://docs.astral.sh/ruff/rules/
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+#    "UP",
+    # flake8-bugbear
+#    "B",
+    # flake8-simplify
+#    "SIM",
+    # isort
+    "I",
+    # flake8-bandit
+    "S",
+]
+
+[tool.ruff.lint.isort]
+force-single-line = true
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dev = [
     "codecov",
     "flake8",
     "tox-gh-actions",
-    "ruff"
+    "ruff",
+    "matplotlib"
 ]
 docs = [
     "doc8",
@@ -105,6 +106,8 @@ commands =
 line-length = 127
 exclude = [
     "docs",
+    "examples_old",
+    "tests"
 ]
 
 [tool.ruff.format]

--- a/resources/scripts/generate_html.py
+++ b/resources/scripts/generate_html.py
@@ -2,6 +2,7 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.0.1"
 
 import sys
+
 import requests
 
 org = "easyScience"

--- a/resources/scripts/generate_html.py
+++ b/resources/scripts/generate_html.py
@@ -1,29 +1,31 @@
-__author__ = "github.com/wardsimon"
-__version__ = "0.0.1"
+__author__ = 'github.com/wardsimon'
+__version__ = '0.0.1'
 
 import sys
 
 import requests
 
-org = "easyScience"
-repo = "easyCore"
+org = 'easyScience'
+repo = 'easyCore'
 if len(sys.argv) > 1:
     repo = sys.argv[1]
 
-releases = requests.get(f"https://api.github.com/repos/{org}/{repo}/releases").json()
+releases = requests.get(f'https://api.github.com/repos/{org}/{repo}/releases').json()  # noqa: S113
 
-header = f"<!DOCTYPE html>\n<html>\n<head>\n<title>Links for {repo} (alpha)</title>\n</head>\n<body>\n<h1>Links for {repo}</h1>"
-body = ""
+header = (
+    f'<!DOCTYPE html>\n<html>\n<head>\n<title>Links for {repo} (alpha)</title>\n</head>\n<body>\n<h1>Links for {repo}</h1>'
+)
+body = ''
 for release in releases:
-    asset_url = release["assets_url"]
-    assets = requests.get(asset_url).json()
+    asset_url = release['assets_url']
+    assets = requests.get(asset_url).json()  # noqa: S113
     for asset in assets:
-        if asset["name"].endswith(".whl"):
-            name = asset["name"][:-4]
-            url = asset["browser_download_url"]
+        if asset['name'].endswith('.whl'):
+            name = asset['name'][:-4]
+            url = asset['browser_download_url']
             body += f'<a href="{url}" data-requires-python="&gt=3.7,&lt4.0">{name}</a><br/>\n'
-footer = "</body>\n</html>"
+footer = '</body>\n</html>'
 
-content = "\n".join([header, body, footer])
-with open("index.html", "w") as fid:
+content = '\n'.join([header, body, footer])
+with open('index.html', 'w') as fid:
     fid.write(content)

--- a/tests/coords.py
+++ b/tests/coords.py
@@ -13,11 +13,10 @@ boundary conditions or otherwise. Many of these are heavily vectorized in
 numpy for performance.
 """
 
-import math
 import itertools
+import math
 
 import numpy as np
-
 import pyximport
 
 pyximport.install(setup_args={"include_dirs": np.get_include()})

--- a/tests/integration_tests/test_undoRedo.py
+++ b/tests/integration_tests/test_undoRedo.py
@@ -5,14 +5,15 @@
 __author__ = "github.com/wardsimon"
 __version__ = "0.0.1"
 
-import pytest
 import math
 
 import numpy as np
+import pytest
 
-from easyCore.Objects.Variable import Descriptor, Parameter
-from easyCore.Objects.ObjectClasses import BaseObj
 from easyCore.Objects.Groups import BaseCollection
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.Variable import Descriptor
+from easyCore.Objects.Variable import Parameter
 
 
 def createSingleObjs(idx):

--- a/tests/unit_tests/Fitting/test_constraints.py
+++ b/tests/unit_tests/Fitting/test_constraints.py
@@ -5,13 +5,13 @@ __version__ = "0.1.0"
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
+from typing import List
+from typing import Tuple
+
 import pytest
 
-from typing import List, Tuple
-from easyCore.Fitting.Constraints import (
-    NumericConstraint,
-    ObjConstraint,
-)
+from easyCore.Fitting.Constraints import NumericConstraint
+from easyCore.Fitting.Constraints import ObjConstraint
 from easyCore.Objects.Variable import Parameter
 
 

--- a/tests/unit_tests/Fitting/test_constraints.py
+++ b/tests/unit_tests/Fitting/test_constraints.py
@@ -11,7 +11,6 @@ from typing import List, Tuple
 from easyCore.Fitting.Constraints import (
     NumericConstraint,
     ObjConstraint,
-    SelfConstraint,
 )
 from easyCore.Objects.Variable import Parameter
 

--- a/tests/unit_tests/Fitting/test_fitting.py
+++ b/tests/unit_tests/Fitting/test_fitting.py
@@ -8,11 +8,14 @@ __version__ = "0.0.1"
 from typing import ClassVar
 
 import pytest
+
 from easyCore import np
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
-from easyCore.Fitting.Fitting import Fitter, MultiFitter
-from easyCore.Fitting.fitting_template import FitError
 from easyCore.Fitting.Constraints import ObjConstraint
+from easyCore.Fitting.Fitting import Fitter
+from easyCore.Fitting.Fitting import MultiFitter
+from easyCore.Fitting.fitting_template import FitError
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Parameter
 
 
 class AbsSin(BaseObj):

--- a/tests/unit_tests/Fitting/test_fitting.py
+++ b/tests/unit_tests/Fitting/test_fitting.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 
 import pytest
 
-from easyCore import np
+import numpy as np
 from easyCore.Fitting.Constraints import ObjConstraint
 from easyCore.Fitting.Fitting import Fitter
 from easyCore.Fitting.Fitting import MultiFitter

--- a/tests/unit_tests/Objects/test_BaseObj.py
+++ b/tests/unit_tests/Objects/test_BaseObj.py
@@ -5,14 +5,20 @@ __version__ = "0.1.0"
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
-import pytest
-import numpy as np
-
-from typing import List, Type, Union, ClassVar, Optional
 from contextlib import contextmanager
+from typing import ClassVar
+from typing import List
+from typing import Optional
+from typing import Type
+from typing import Union
+
+import numpy as np
+import pytest
 
 import easyCore
-from easyCore.Objects.ObjectClasses import Descriptor, Parameter, BaseObj
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Descriptor
+from easyCore.Objects.ObjectClasses import Parameter
 from easyCore.Utils.io.dict import DictSerializer
 
 
@@ -300,9 +306,10 @@ def test_baseObj_name(setup_pars):
 
 
 def test_subclassing():
+    from typing import ClassVar
+
     from easyCore.models.polynomial import Line
     from easyCore.Objects.Variable import Parameter
-    from typing import ClassVar
 
     class L2(Line):
         diff: ClassVar[Parameter]

--- a/tests/unit_tests/Objects/test_Descriptor_Parameter.py
+++ b/tests/unit_tests/Objects/test_Descriptor_Parameter.py
@@ -8,17 +8,16 @@ __version__ = "0.1.0"
 from copy import deepcopy
 from typing import List
 
-import pytest
 import numpy as np
+import pytest
+
 import easyCore
-from easyCore.Objects.Variable import (
-    Descriptor,
-    Parameter,
-    ureg,
-    Q_,
-    CoreSetException,
-    borg,
-)
+from easyCore.Objects.Variable import Q_
+from easyCore.Objects.Variable import CoreSetException
+from easyCore.Objects.Variable import Descriptor
+from easyCore.Objects.Variable import Parameter
+from easyCore.Objects.Variable import borg
+from easyCore.Objects.Variable import ureg
 
 
 @pytest.fixture

--- a/tests/unit_tests/Objects/test_Groups.py
+++ b/tests/unit_tests/Objects/test_Groups.py
@@ -8,10 +8,12 @@ __version__ = "0.1.0"
 from typing import List
 
 import pytest
-import easyCore
 
+import easyCore
 from easyCore.Objects.Groups import BaseCollection
-from easyCore.Objects.ObjectClasses import Descriptor, Parameter, BaseObj
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Descriptor
+from easyCore.Objects.ObjectClasses import Parameter
 
 test_dict = {
     "@module": "easyCore.Objects.Groups",

--- a/tests/unit_tests/Objects/test_Virtual.py
+++ b/tests/unit_tests/Objects/test_Virtual.py
@@ -7,7 +7,7 @@ __version__ = "0.0.1"
 
 import pytest
 from easyCore.Objects import virtual as Virtual
-from easyCore.Objects.Variable import Parameter, Descriptor
+from easyCore.Objects.Variable import Parameter
 from easyCore.models.polynomial import Line
 
 

--- a/tests/unit_tests/Objects/test_Virtual.py
+++ b/tests/unit_tests/Objects/test_Virtual.py
@@ -6,9 +6,10 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.0.1"
 
 import pytest
+
+from easyCore.models.polynomial import Line
 from easyCore.Objects import virtual as Virtual
 from easyCore.Objects.Variable import Parameter
-from easyCore.models.polynomial import Line
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/Objects/test_graph.py
+++ b/tests/unit_tests/Objects/test_graph.py
@@ -5,4 +5,3 @@ __version__ = "0.1.0"
 #  SPDX-License-Identifier: BSD-3-Clause
 #  © 2021-2023 Contributors to the easyCore project <https://github.com/easyScience/easyCore
 
-import pytest

--- a/tests/unit_tests/models/test_polynomial.py
+++ b/tests/unit_tests/models/test_polynomial.py
@@ -5,10 +5,12 @@
 __author__ = "github.com/wardsimon"
 __version__ = "0.0.1"
 
-import pytest
 import numpy as np
+import pytest
+
+from easyCore.models.polynomial import Line
+from easyCore.models.polynomial import Polynomial
 from easyCore.Objects.Variable import Parameter
-from easyCore.models.polynomial import Line, Polynomial
 
 line_test_cases = ((1, 2), (-1, -2), (0.72, 6.48))
 poly_test_cases = (

--- a/tests/unit_tests/utils/io_tests/test_core.py
+++ b/tests/unit_tests/utils/io_tests/test_core.py
@@ -2,14 +2,12 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.0.1"
 
 from copy import deepcopy
-from typing import Union, Type
+from typing import Type
 
 import pytest
 import easyCore
 
-from easyCore.models.polynomial import Line
 from easyCore.Objects.ObjectClasses import BaseObj, Parameter, Descriptor
-from easyCore.Objects.Groups import BaseCollection
 
 
 dp_param_dict = {
@@ -54,7 +52,7 @@ dp_param_dict = {
 }
 
 _skip_opt = [[], None] + [
-    k for k in dp_param_dict["argvalues"][0][0].keys() if k[0] is not "@"
+    k for k in dp_param_dict["argvalues"][0][0].keys() if k[0] != "@"
 ]
 skip_dict = {
     "argnames": "skip",

--- a/tests/unit_tests/utils/io_tests/test_core.py
+++ b/tests/unit_tests/utils/io_tests/test_core.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from typing import Type
 
 import pytest
-import numpy as np
 
 import easyCore
 from easyCore.Objects.ObjectClasses import BaseObj
@@ -39,8 +38,8 @@ dp_param_dict = {
                 "units": "kilometer",
                 "value": 1.0,
                 "error": 0.0,
-                "min": -np.inf,
-                "max": np.inf,
+                "min": -easyCore.np.inf,
+                "max": easyCore.np.inf,
                 "fixed": False,
                 "url": "https://www.boo.com",
                 "description": "",

--- a/tests/unit_tests/utils/io_tests/test_core.py
+++ b/tests/unit_tests/utils/io_tests/test_core.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import Type
 
 import pytest
+import numpy
 
 import easyCore
 from easyCore.Objects.ObjectClasses import BaseObj
@@ -38,8 +39,8 @@ dp_param_dict = {
                 "units": "kilometer",
                 "value": 1.0,
                 "error": 0.0,
-                "min": -easyCore.np.inf,
-                "max": easyCore.np.inf,
+                "min": -numpy.inf,
+                "max": numpy.inf,
                 "fixed": False,
                 "url": "https://www.boo.com",
                 "description": "",

--- a/tests/unit_tests/utils/io_tests/test_core.py
+++ b/tests/unit_tests/utils/io_tests/test_core.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from typing import Type
 
 import pytest
-import numpy
+import numpy as np
 
 import easyCore
 from easyCore.Objects.ObjectClasses import BaseObj
@@ -39,8 +39,8 @@ dp_param_dict = {
                 "units": "kilometer",
                 "value": 1.0,
                 "error": 0.0,
-                "min": -numpy.inf,
-                "max": numpy.inf,
+                "min": -np.inf,
+                "max": np.inf,
                 "fixed": False,
                 "url": "https://www.boo.com",
                 "description": "",

--- a/tests/unit_tests/utils/io_tests/test_core.py
+++ b/tests/unit_tests/utils/io_tests/test_core.py
@@ -5,10 +5,11 @@ from copy import deepcopy
 from typing import Type
 
 import pytest
+
 import easyCore
-
-from easyCore.Objects.ObjectClasses import BaseObj, Parameter, Descriptor
-
+from easyCore.Objects.ObjectClasses import BaseObj
+from easyCore.Objects.ObjectClasses import Descriptor
+from easyCore.Objects.ObjectClasses import Parameter
 
 dp_param_dict = {
     "argnames": "dp_kwargs, dp_cls",

--- a/tests/unit_tests/utils/io_tests/test_dict.py
+++ b/tests/unit_tests/utils/io_tests/test_dict.py
@@ -6,8 +6,17 @@ from typing import Type
 
 import numpy as np
 import pytest
-from .test_core import dp_param_dict, skip_dict, check_dict, A, B, Descriptor, BaseObj
-from easyCore.Utils.io.dict import DictSerializer, DataDictSerializer
+
+from easyCore.Utils.io.dict import DataDictSerializer
+from easyCore.Utils.io.dict import DictSerializer
+
+from .test_core import A
+from .test_core import B
+from .test_core import BaseObj
+from .test_core import Descriptor
+from .test_core import check_dict
+from .test_core import dp_param_dict
+from .test_core import skip_dict
 
 
 def recursive_remove(d, remove_keys: list) -> dict:

--- a/tests/unit_tests/utils/io_tests/test_json.py
+++ b/tests/unit_tests/utils/io_tests/test_json.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from typing import Type
 
 import pytest
-from .test_core import dp_param_dict, skip_dict, check_dict, A, Descriptor, Parameter
+from .test_core import dp_param_dict, skip_dict, check_dict, A, Descriptor
 from easyCore.Utils.io.json import JsonSerializer, JsonDataSerializer
 
 

--- a/tests/unit_tests/utils/io_tests/test_json.py
+++ b/tests/unit_tests/utils/io_tests/test_json.py
@@ -6,8 +6,15 @@ from copy import deepcopy
 from typing import Type
 
 import pytest
-from .test_core import dp_param_dict, skip_dict, check_dict, A, Descriptor
-from easyCore.Utils.io.json import JsonSerializer, JsonDataSerializer
+
+from easyCore.Utils.io.json import JsonDataSerializer
+from easyCore.Utils.io.json import JsonSerializer
+
+from .test_core import A
+from .test_core import Descriptor
+from .test_core import check_dict
+from .test_core import dp_param_dict
+from .test_core import skip_dict
 
 
 def recursive_remove(d, remove_keys: list) -> dict:

--- a/tests/unit_tests/utils/io_tests/test_star.py
+++ b/tests/unit_tests/utils/io_tests/test_star.py
@@ -6,10 +6,14 @@ __author__ = "github.com/wardsimon"
 __version__ = "0.0.1"
 
 import pytest
-from easyCore.Utils.io.star import ItemHolder, StarLoop, StarSection
-from easyCore.Objects.Variable import Parameter, Descriptor
+
 from easyCore.models.polynomial import Line
 from easyCore.Objects.Groups import BaseCollection
+from easyCore.Objects.Variable import Descriptor
+from easyCore.Objects.Variable import Parameter
+from easyCore.Utils.io.star import ItemHolder
+from easyCore.Utils.io.star import StarLoop
+from easyCore.Utils.io.star import StarSection
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/utils/io_tests/test_xml.py
+++ b/tests/unit_tests/utils/io_tests/test_xml.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from typing import Type
 
 import pytest
-from .test_core import dp_param_dict, skip_dict, check_dict, A, B, Descriptor, Parameter
+from .test_core import dp_param_dict, skip_dict, A, Descriptor
 from easyCore.Utils.io.xml import XMLSerializer
 
 

--- a/tests/unit_tests/utils/io_tests/test_xml.py
+++ b/tests/unit_tests/utils/io_tests/test_xml.py
@@ -7,8 +7,13 @@ from copy import deepcopy
 from typing import Type
 
 import pytest
-from .test_core import dp_param_dict, skip_dict, A, Descriptor
+
 from easyCore.Utils.io.xml import XMLSerializer
+
+from .test_core import A
+from .test_core import Descriptor
+from .test_core import dp_param_dict
+from .test_core import skip_dict
 
 
 def recursive_remove(d, remove_keys: list) -> dict:


### PR DESCRIPTION
`pyproject.yml`
- Changed hatchling
- Added ruff specifications

`easyCore`
- imports of `np` are longer from `easyCore` but instead: `import numpy as np`
  - tests/unit_tests/utils/io_tests/test_core.py
  - the above mentioned change is apparent in the `test_core` where easyCore.inf is replaced by np.inf
- different changes to satisfy ruff
- no changes to logic